### PR TITLE
Add .jvmopts

### DIFF
--- a/.jvmopts
+++ b/.jvmopts
@@ -1,0 +1,6 @@
+-Xms2048M
+-Xmx2048M
+-Xss6M
+-XX:ReservedCodeCacheSize=256M
+-Dfile.encoding=UTF-8
+--add-opens=java.base/java.lang=ALL-UNNAMED


### PR DESCRIPTION
After spending ages not realising that the lagom service discovery is not working on Java 16+ because `--add-opens` was not being applied to the sbt project and that the locator/gateway run in the sbt process anyway, I think it would be prudent to add a `.jvmopts` file rather than have people muck around with environment variables.

However, when attempting this earlier, the version of Java 16 (adopt hotspot) didn't seem to recognise `--add-opens`, even though it should be valid.

We should not rely on the `--illegal-access` flag as it's gone in Java 17, and Java 16 is no longer supported.

This PR is mostly for seeing how actions reacts.