### PR TITLE
Make CORS more liberal - makes sense to just use * as a default

### DIFF
--- a/artifact-impl/src/main/resources/application.conf
+++ b/artifact-impl/src/main/resources/application.conf
@@ -20,7 +20,7 @@ play.filters.disabled += "play.filters.csrf.CSRFFilter"
 play.filters.enabled += "play.filters.cors.CORSFilter"
 play.filters.cors {
   pathPrefixes = ["/artifacts-query"]
-  allowedOrigins = ["http://localhost:8080/"]
+  allowedOrigins = ["*"]
   allowedOrigins = [${?CORS_ORIGIN}]
   allowedHttpMethods = ["GET", "POST"]
   preflightMaxAge = 3 days

--- a/artifact-query-impl/src/main/resources/application.conf
+++ b/artifact-query-impl/src/main/resources/application.conf
@@ -25,7 +25,7 @@ play.filters.enabled += "play.filters.cors.CORSFilter"
 play.filters.disabled += "play.filters.csrf.CSRFFilter"
 play.filters.cors {
   pathPrefixes = ["/artifacts"-query]
-  allowedOrigins = ["http://localhost:8080/"]
+  allowedOrigins = ["*"]
   allowedOrigins = [${?CORS_ORIGIN}]
   allowedHttpMethods = ["GET"]
   preflightMaxAge = 3 days

--- a/auth-impl/src/main/resources/application.conf
+++ b/auth-impl/src/main/resources/application.conf
@@ -15,7 +15,7 @@ play.filters.csrf.header.protectHeaders = null
 play.filters.disabled += "play.filters.csrf.CSRFFilter"
 play.filters.cors {
   pathPrefixes = ["/auth"]
-  allowedOrigins = ["http://localhost:9000/"]
+  allowedOrigins = ["*:"]
   allowedOrigins = [${?CORS_ORIGIN}]
   allowedHttpMethods = ["GET", "POST"]
   preflightMaxAge = 3 days

--- a/versions-impl/src/main/resources/application.conf
+++ b/versions-impl/src/main/resources/application.conf
@@ -36,7 +36,7 @@ play.filters.disabled += "play.filters.csrf.CSRFFilter"
 play.filters.enabled += "play.filters.cors.CORSFilter"
 play.filters.cors {
   pathPrefixes = ["/versions"]
-  allowedOrigins = ["http://localhost:8080/"]
+  allowedOrigins = ["*"]
   allowedOrigins = [${?CORS_ORIGIN}]
   allowedHttpMethods = ["GET", "POST"]
   preflightMaxAge = 3 days

--- a/versions-query-impl/src/main/resources/application.conf
+++ b/versions-query-impl/src/main/resources/application.conf
@@ -24,7 +24,7 @@ akka.serialization.jackson {
 play.filters.enabled += "play.filters.cors.CORSFilter"
 play.filters.cors {
   pathPrefixes = ["/versions-query"]
-  allowedOrigins = ["http://localhost:8080/"]
+  allowedOrigins = ["*"]
   allowedOrigins = [${?CORS_ORIGIN}]
   allowedHttpMethods = ["GET", "POST"]
   preflightMaxAge = 3 days


### PR DESCRIPTION
Just pull as and when - want to make sure I'm not treading on your toes. Doing some work on CORS stuff made me realise that this is probably the way to go for now, we can always tighten it up using the env variables once login is a properly supported feature (but with how we'll likely handle JWTs, this may not be an issue anyway).

If you don't want to do this, make sure terraform sets the `CORS_ORIGIN` env variable correctly, make it `*` at first until we have a proper staging setup... set up.