### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/SpongePowered/SystemOfADownload/security/code-scanning/4](https://github.com/SpongePowered/SystemOfADownload/security/code-scanning/4)

In general, the fix is to explicitly configure `permissions` for the `GITHUB_TOKEN` either at the workflow root (to apply to all jobs) or per job. Since all four jobs (`test`, `lint`, `generate`, `build`) only need to read the repository contents and do not perform any operations that modify GitHub resources, a single root-level `permissions` block setting `contents: read` is the simplest and least invasive fix.

The best change without altering existing functionality is to add a `permissions:` section near the top of `.github/workflows/ci.yml`, alongside `name` and `on`. This block will apply to all jobs because none of them currently declare their own `permissions`. We should set `contents: read` as a minimal, secure default, matching the suggestion from CodeQL. No other scopes (like `pull-requests: write`, `issues: write`, etc.) appear necessary based on the current steps, which only read code, run tests, generate code locally, and upload coverage to an external service.

Concretely, in `.github/workflows/ci.yml`, insert:

```yaml
permissions:
  contents: read
```

between the `name: CI` line (line 1) and the `on:` block (line 3), adjusting indentation to align with root keys. No imports, methods, or other definitions are needed, since this is purely a YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
