### PR TITLE
Feat/silence health logs

### DIFF
--- a/cmd/frontend/main.go
+++ b/cmd/frontend/main.go
@@ -115,20 +115,29 @@ func NewOTel(lc fx.Lifecycle, logs *logging.Result) *otelsetup.Result {
 func NewMux(fe *frontend.Server, otel *otelsetup.Result) http.Handler {
 	mux := http.NewServeMux()
 
-	fe.RegisterRoutes(mux, otel.MetricsHandler)
+	fe.RegisterRoutes(mux)
 
 	logger := httplog.NewLogger("soad-frontend", httplog.Options{
-		LogLevel:        slog.LevelInfo,
-		JSON:            true,
-		Concise:         true,
-		RequestHeaders:  true,
-		Writer:          os.Stderr,
-		QuietDownRoutes: []string{"/healthz", "/metrics"},
-		QuietDownPeriod: 10 * time.Second,
+		LogLevel:       slog.LevelInfo,
+		JSON:           true,
+		Concise:        true,
+		RequestHeaders: true,
+		Writer:         os.Stderr,
 	})
 
 	handler := gzhttp.GzipHandler(otelhttp.NewHandler(mux, "soad-frontend"))
-	return httplog.RequestLogger(logger)(handler)
+	loggedHandler := httplog.RequestLogger(logger)(handler)
+
+	// Outer mux: /healthz and /metrics bypass request logging.
+	outer := http.NewServeMux()
+	outer.HandleFunc("GET /healthz", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprintln(w, "OK")
+	})
+	outer.Handle("GET /metrics", otel.MetricsHandler)
+	outer.Handle("/", loggedHandler)
+
+	return outer
 }
 
 func NewHTTPServer(lc fx.Lifecycle, cfg *Config, handler http.Handler, s fx.Shutdowner) *http.Server {

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -172,24 +172,27 @@ func NewMux(h *httpapi.Handler, cfg *Config, otel *otelsetup.Result) http.Handle
 	apiHandler := api.NewStrictHandler(h, middlewares)
 	mux := http.NewServeMux()
 
-	mux.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
-		_, _ = fmt.Fprintln(w, "OK")
-	})
-	mux.Handle("/metrics", otel.MetricsHandler)
-
 	logger := httplog.NewLogger("soad-server", httplog.Options{
-		LogLevel:        slog.LevelInfo,
-		JSON:            true,
-		Concise:         true,
-		RequestHeaders:  true,
-		Writer:          os.Stderr,
-		QuietDownRoutes: []string{"/healthz", "/metrics"},
-		QuietDownPeriod: 10 * time.Second,
+		LogLevel:       slog.LevelInfo,
+		JSON:           true,
+		Concise:        true,
+		RequestHeaders: true,
+		Writer:         os.Stderr,
 	})
 
 	handler := otelhttp.NewHandler(api.HandlerFromMux(apiHandler, mux), "soad-server")
-	return httplog.RequestLogger(logger)(handler)
+	loggedHandler := httplog.RequestLogger(logger)(handler)
+
+	// Outer mux: /healthz and /metrics bypass request logging.
+	outer := http.NewServeMux()
+	outer.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprintln(w, "OK")
+	})
+	outer.Handle("/metrics", otel.MetricsHandler)
+	outer.Handle("/", loggedHandler)
+
+	return outer
 }
 
 func main() {

--- a/internal/frontend/server.go
+++ b/internal/frontend/server.go
@@ -70,9 +70,11 @@ func NewServer(service *app.Service, cfg ServerConfig) (*Server, error) {
 }
 
 // RegisterRoutes mounts all frontend routes onto the given mux.
-// Specific routes (/healthz, /settings, /assets/) must be registered before
+// Specific routes (/settings, /assets/) must be registered before
 // the catch-all /{project} wildcard to avoid conflicts.
-func (s *Server) RegisterRoutes(mux *http.ServeMux, metricsHandler http.Handler) {
+// Infrastructure routes (/healthz, /metrics) are registered on a
+// separate outer mux by the caller so they bypass request logging.
+func (s *Server) RegisterRoutes(mux *http.ServeMux) {
 	// Static assets (CSS, fonts, picker JS) — embedded in the binary and
 	// served under content-hashed URLs so Cache-Control: immutable is
 	// safe. Templates must reference these through `{{asset "..."}}`.
@@ -93,15 +95,8 @@ func (s *Server) RegisterRoutes(mux *http.ServeMux, metricsHandler http.Handler)
 	staticSub, _ := fs.Sub(staticFS, "static")
 	mux.Handle("GET /favicon.ico", http.FileServer(http.FS(staticSub)))
 
-	mux.HandleFunc("GET /healthz", s.handleHealthz)
-	mux.Handle("GET /metrics", metricsHandler)
 	mux.HandleFunc("GET /settings", s.handleSettings)
 	mux.HandleFunc("POST /settings", s.handleSettingsSubmit)
 	mux.HandleFunc("GET /{$}", s.handleOverview)
 	mux.HandleFunc("GET /{project}", s.handleDownloads)
-}
-
-func (s *Server) handleHealthz(w http.ResponseWriter, r *http.Request) {
-	w.WriteHeader(http.StatusOK)
-	_, _ = fmt.Fprintln(w, "OK")
 }

--- a/internal/httpapi/handler.go
+++ b/internal/httpapi/handler.go
@@ -27,6 +27,10 @@ import (
 
 var apiMeter = otel.Meter("soad.httpapi")
 
+// MaxVersionsPageLimit is the maximum page size accepted for GetVersions. Larger
+// values are clamped down; the openapi spec advertises this as the maximum.
+const MaxVersionsPageLimit int32 = 25
+
 // VersionSyncScheduleID returns the Temporal Schedule ID for a given artifact's
 // periodic version sync. Used by both RegisterArtifact (schedule creation) and
 // TriggerSync (on-demand trigger).
@@ -273,11 +277,14 @@ func (h *Handler) GetArtifact(ctx context.Context, request api.GetArtifactReques
 
 func (h *Handler) GetVersions(ctx context.Context, request api.GetVersionsRequestObject) (api.GetVersionsResponseObject, error) {
 	h.countRequest(ctx, "GetVersions")
-	limit := int32(25)
+	limit := MaxVersionsPageLimit
 	if request.Params.Limit != nil {
 		l := int32(*request.Params.Limit)
-		if l < 1 || l > 25 {
-			return NewGetVersionsBadRequestError("limit must be between 1 and 25"), nil
+		if l < 1 {
+			return NewGetVersionsBadRequestError("limit must be at least 1"), nil
+		}
+		if l > MaxVersionsPageLimit {
+			l = MaxVersionsPageLimit
 		}
 		limit = l
 	}

--- a/internal/httpapi/handler_test.go
+++ b/internal/httpapi/handler_test.go
@@ -428,18 +428,22 @@ func TestGetVersions(t *testing.T) {
 		}
 	})
 
-	t.Run("returns 400 for invalid limit", func(t *testing.T) {
-		badLimit := 50
+	t.Run("clamps limit above max to 25", func(t *testing.T) {
+		overLimit := 50
 		resp, err := handler.GetVersions(ctx, api.GetVersionsRequestObject{
 			GroupID:    "org.spongepowered",
 			ArtifactID: "spongeforge",
-			Params:     api.GetVersionsParams{Limit: &badLimit},
+			Params:     api.GetVersionsParams{Limit: &overLimit},
 		})
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		if _, ok := resp.(*GetVersionsBadRequestError); !ok {
-			t.Errorf("expected 400, got %T", resp)
+		ordered, ok := resp.(*orderedVersionsResponse)
+		if !ok {
+			t.Fatalf("expected ordered versions response, got %T", resp)
+		}
+		if ordered.Limit != 25 {
+			t.Errorf("expected limit clamped to 25, got %d", ordered.Limit)
 		}
 	})
 

--- a/internal/httpapi/integration_test.go
+++ b/internal/httpapi/integration_test.go
@@ -3,8 +3,11 @@ package httpapi_test
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -338,16 +341,23 @@ func TestIntegration_GroupAndArtifactLifecycle(t *testing.T) {
 		}
 	})
 
-	// Step 13: GetVersions returns 400 for invalid limit
-	t.Run("get versions with invalid limit returns 400", func(t *testing.T) {
+	// Step 13: GetVersions clamps over-max limit to the advertised maximum
+	t.Run("get versions clamps over-max limit", func(t *testing.T) {
 		resp, err := client.Get(baseURL + "/groups/org.spongepowered/artifacts/spongevanilla/versions?limit=50")
 		if err != nil {
 			t.Fatalf("failed to get versions: %v", err)
 		}
 		defer func() { _ = resp.Body.Close() }()
 
-		if resp.StatusCode != http.StatusBadRequest {
-			t.Fatalf("expected status 400, got %d", resp.StatusCode)
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("expected status 200, got %d", resp.StatusCode)
+		}
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			t.Fatalf("failed to read body: %v", err)
+		}
+		if !strings.Contains(string(body), fmt.Sprintf(`"limit":%d`, httpapi.MaxVersionsPageLimit)) {
+			t.Fatalf("expected clamped limit=%d in body, got %s", httpapi.MaxVersionsPageLimit, body)
 		}
 	})
 


### PR DESCRIPTION
## Description

This pull request refactors how infrastructure routes (`/healthz` and `/metrics`) are registered and handled, ensuring they bypass request logging and are not affected by application-level middleware. It also improves the `GetVersions` API endpoint by clamping the `limit` parameter to a maximum value instead of returning an error, and updates tests to reflect this behavior.

**Infrastructure route handling:**

* Moved registration of `/healthz` and `/metrics` routes out of `RegisterRoutes` in `internal/frontend/server.go` so they are now registered in an outer mux by the caller, ensuring these routes bypass request logging and middleware. The `RegisterRoutes` method signature was updated accordingly. [[1]](diffhunk://#diff-c200412d280c35a436a78550905b2de511c601d28bb1aefa0077a2c122d35d50L73-R77) [[2]](diffhunk://#diff-c200412d280c35a436a78550905b2de511c601d28bb1aefa0077a2c122d35d50L96-L107) [[3]](diffhunk://#diff-5dd75aae27760b3f3e874528b7ede3ee9c5bef8aaef7a784d10e0f043a4d2b24L118-R140) [[4]](diffhunk://#diff-53cd25fc908d5e63cc8675afbd4ff0910572a985a7cfec27f4460eb674f3b98eL175-R195)

**API parameter validation and clamping:**

* Introduced `MaxVersionsPageLimit` constant and updated the `GetVersions` handler to clamp the `limit` parameter to this maximum (25) instead of returning a 400 error if the value is too high; values below 1 still return a 400 error. [[1]](diffhunk://#diff-e10c837e6b2d6f21db89474a47933efe5582d35dc1883e1b8b1cc91aa830367eR30-R33) [[2]](diffhunk://#diff-e10c837e6b2d6f21db89474a47933efe5582d35dc1883e1b8b1cc91aa830367eL276-R287)

**Test updates:**

* Updated unit and integration tests to expect clamping behavior for over-max `limit` values, checking that the response uses the clamped value and returns HTTP 200 instead of HTTP 400. [[1]](diffhunk://#diff-86b0644aa9bdf6fe6a0fb1abf63d1bdb9d573e611551c9f13523be2121aa7625L431-R446) [[2]](diffhunk://#diff-ea95fcb9980d96d24842708993bb6b3f8f290ec6e444fb6b91e4161281114cffL341-R360) [[3]](diffhunk://#diff-ea95fcb9980d96d24842708993bb6b3f8f290ec6e444fb6b91e4161281114cffR6-R10)

These changes improve observability by keeping infrastructure routes out of logs and make the API more user-friendly by handling out-of-range parameters gracefully.

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [ ] `feat`: New feature (non-breaking change which adds functionality)
- [x] `fix`: Bug fix (non-breaking change which fixes an issue)
- [ ] `docs`: Documentation update
- [ ] `refactor`: Code refactoring (no functional changes)
- [ ] `perf`: Performance improvement
- [ ] `test`: Adding or updating tests
- [x] `chore`: Maintenance tasks (dependencies, tooling, etc.)
- [ ] `ci`: CI/CD configuration changes
- [ ] **BREAKING CHANGE**: This change breaks backwards compatibility

## Testing

<!-- Describe the tests you ran and how to reproduce them -->

- [xx] Tests pass locally with `go test ./...`
- [ ] Added/updated tests for new functionality
- [ ] Generated code is up to date (`go generate ./...`)

## Commit Message Format

<!-- 
Ensure your PR title follows conventional commits format:
- feat: add new feature
- fix: correct bug
- docs: update documentation

See RELEASES.md for more details.
-->

## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have run `go generate ./...` to update generated code
- [ ] I have updated documentation as needed
- [ ] My changes do not introduce new warnings or errors
- [ ] I have added tests that prove my fix/feature works
- [ ] All tests pass locally
