### PR TITLE
feat: add clickable GitHub profile links to contributors

### DIFF
--- a/api/api.gen.go
+++ b/api/api.gen.go
@@ -118,8 +118,9 @@ type Asset struct {
 // Commit defines model for Commit.
 type Commit struct {
 	Author *struct {
-		Email *string `json:"email,omitempty"`
-		Name  *string `json:"name,omitempty"`
+		Email          *string `json:"email,omitempty"`
+		GithubUsername *string `json:"githubUsername,omitempty"`
+		Name           *string `json:"name,omitempty"`
 	} `json:"author,omitempty"`
 	Body       *string             `json:"body,omitempty"`
 	CommitDate *openapi_types.Date `json:"commitDate,omitempty"`

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -24,6 +24,7 @@ import (
 	"github.com/spongepowered/systemofadownload/internal/httpapi"
 	"github.com/spongepowered/systemofadownload/internal/otelsetup"
 	"github.com/spongepowered/systemofadownload/internal/repository"
+	"go.temporal.io/sdk/temporal"
 )
 
 type Config struct {
@@ -90,6 +91,21 @@ func NewTemporalClient(lc fx.Lifecycle, cfg *Config) (client.Client, error) {
 		},
 	})
 	return c, nil
+}
+
+func EnsureGitHubAuthorResolutionSchedule(
+	lc fx.Lifecycle,
+	schedules client.ScheduleClient,
+) {
+	lc.Append(fx.Hook{
+		OnStart: func(ctx context.Context) error {
+			_, err := schedules.Create(ctx, httpapi.NewGitHubAuthorResolutionScheduleOptions())
+			if err == nil || errors.Is(err, temporal.ErrScheduleAlreadyRunning) {
+				return nil
+			}
+			return fmt.Errorf("creating GitHub author resolution schedule: %w", err)
+		},
+	})
 }
 
 func NewDBPool(lc fx.Lifecycle, cfg *Config) (*pgxpool.Pool, error) {
@@ -219,6 +235,9 @@ func main() {
 			NewMux,
 			NewHTTPServer,
 		),
-		fx.Invoke(func(*http.Server) {}),
+		fx.Invoke(
+			func(*http.Server) {},
+			EnsureGitHubAuthorResolutionSchedule,
+		),
 	).Run()
 }

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -207,6 +207,7 @@ func NewTemporalWorker(
 	indexActivities *activity.VersionIndexActivities,
 	orderingActivities *activity.VersionOrderingActivities,
 	changelogActivities *activity.ChangelogActivities,
+	githubAuthorActivities *activity.GitHubAuthorResolutionActivities,
 	gitActivities *activity.GitActivities,
 ) worker.Worker {
 	w := worker.New(c, wf.VersionSyncTaskQueue, worker.Options{
@@ -230,10 +231,12 @@ func NewTemporalWorker(
 	w.RegisterWorkflow(wf.EnrichVersionWorkflow)
 	w.RegisterWorkflow(wf.ChangelogBatchWorkflow)
 	w.RegisterWorkflow(wf.ChangelogVersionWorkflow)
+	w.RegisterWorkflow(wf.GitHubAuthorResolutionWorkflow)
 	w.RegisterActivity(syncActivities)
 	w.RegisterActivity(indexActivities)
 	w.RegisterActivity(orderingActivities)
 	w.RegisterActivity(changelogActivities)
+	w.RegisterActivity(githubAuthorActivities)
 	w.RegisterActivity(gitActivities)
 
 	lc.Append(fx.Hook{
@@ -277,8 +280,11 @@ func main() {
 			},
 			activity.NewVersionIndexActivities,
 			activity.NewVersionOrderingActivities,
-			func(cfg *Config, repo repository.Repository) *activity.ChangelogActivities {
-				return &activity.ChangelogActivities{
+			func(repo repository.Repository) *activity.ChangelogActivities {
+				return &activity.ChangelogActivities{Repo: repo}
+			},
+			func(cfg *Config, repo repository.Repository) *activity.GitHubAuthorResolutionActivities {
+				return &activity.GitHubAuthorResolutionActivities{
 					Repo:   repo,
 					GitHub: githubapi.NewClient(http.DefaultClient, cfg.GitHubToken),
 				}

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/spongepowered/systemofadownload/internal/activity"
 	"github.com/spongepowered/systemofadownload/internal/gitcache"
+	"github.com/spongepowered/systemofadownload/internal/githubapi"
 	"github.com/spongepowered/systemofadownload/internal/otelsetup"
 	"github.com/spongepowered/systemofadownload/internal/repository"
 	"github.com/spongepowered/systemofadownload/internal/sonatype"
@@ -38,6 +39,7 @@ type Config struct {
 	SonatypeRepoDenyList []string
 	DatabaseURL          string
 	GitCacheDir          string
+	GitHubToken          string
 	MetricsPort          string
 	BuildID              string
 	PodName              string
@@ -98,6 +100,7 @@ func NewConfig() *Config {
 		SonatypeRepoDenyList: repoDeny,
 		DatabaseURL:          databaseURL,
 		GitCacheDir:          gitCacheDir,
+		GitHubToken:          os.Getenv("GITHUB_TOKEN"),
 		MetricsPort:          metricsPort,
 		BuildID:              buildID,
 		PodName:              podName,
@@ -274,8 +277,11 @@ func main() {
 			},
 			activity.NewVersionIndexActivities,
 			activity.NewVersionOrderingActivities,
-			func(repo repository.Repository) *activity.ChangelogActivities {
-				return &activity.ChangelogActivities{Repo: repo}
+			func(cfg *Config, repo repository.Repository) *activity.ChangelogActivities {
+				return &activity.ChangelogActivities{
+					Repo:   repo,
+					GitHub: githubapi.NewClient(http.DefaultClient, cfg.GitHubToken),
+				}
 			},
 			func(cfg *Config) *gitcache.Manager {
 				return gitcache.NewManager(cfg.GitCacheDir)

--- a/db/migrations/000006_github_author_resolution.down.sql
+++ b/db/migrations/000006_github_author_resolution.down.sql
@@ -1,3 +1,2 @@
 DROP INDEX IF EXISTS idx_versions_github_authors_unresolved;
-DROP INDEX IF EXISTS idx_github_user_cache_expires_at;
 DROP TABLE IF EXISTS github_user_cache;

--- a/db/migrations/000006_github_author_resolution.down.sql
+++ b/db/migrations/000006_github_author_resolution.down.sql
@@ -1,0 +1,3 @@
+DROP INDEX IF EXISTS idx_versions_github_authors_unresolved;
+DROP INDEX IF EXISTS idx_github_user_cache_expires_at;
+DROP TABLE IF EXISTS github_user_cache;

--- a/db/migrations/000006_github_author_resolution.up.sql
+++ b/db/migrations/000006_github_author_resolution.up.sql
@@ -5,10 +5,11 @@ CREATE TABLE github_user_cache (
     updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
 
-CREATE INDEX idx_github_user_cache_expires_at
-    ON github_user_cache (expires_at);
-
+-- The predicate is duplicated verbatim by ListVersionsNeedingGitHubAuthorResolution.
+-- The schema version is a literal because a partial index predicate cannot be
+-- parameterised; bumping domain.AuthorResolutionSchema needs a new migration
+-- that replaces this index. Guarded by TestAuthorResolutionSchemaMatchesSQL.
 CREATE INDEX idx_versions_github_authors_unresolved
     ON artifact_versions (id DESC)
     WHERE commit_body->>'enrichedAt' IS NOT NULL
-      AND commit_body->>'githubAuthorsResolvedAt' IS NULL;
+      AND (commit_body->'authorResolution'->>'schema') IS DISTINCT FROM '1';

--- a/db/migrations/000006_github_author_resolution.up.sql
+++ b/db/migrations/000006_github_author_resolution.up.sql
@@ -1,0 +1,14 @@
+CREATE TABLE github_user_cache (
+    author_email TEXT PRIMARY KEY,
+    github_username TEXT,
+    expires_at TIMESTAMPTZ NOT NULL,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_github_user_cache_expires_at
+    ON github_user_cache (expires_at);
+
+CREATE INDEX idx_versions_github_authors_unresolved
+    ON artifact_versions (id DESC)
+    WHERE commit_body->>'enrichedAt' IS NOT NULL
+      AND commit_body->>'githubAuthorsResolvedAt' IS NULL;

--- a/db/query.sql
+++ b/db/query.sql
@@ -160,6 +160,39 @@ UPDATE artifact_versions
 SET commit_body = $2
 WHERE id = $1;
 
+-- name: GetArtifactVersionForUpdate :one
+SELECT * FROM artifact_versions
+WHERE id = $1
+FOR UPDATE;
+
+-- name: ListVersionsNeedingGitHubAuthorResolution :many
+SELECT id
+FROM artifact_versions
+WHERE commit_body IS NOT NULL
+  AND commit_body->>'enrichedAt' IS NOT NULL
+  AND commit_body->>'githubAuthorsResolvedAt' IS NULL
+  AND (sqlc.narg('before_id')::bigint IS NULL OR id < sqlc.narg('before_id'))
+ORDER BY id DESC
+LIMIT sqlc.arg('page_size');
+
+-- name: GetGitHubUserCache :one
+SELECT * FROM github_user_cache
+WHERE author_email = LOWER(BTRIM(sqlc.arg('author_email')))
+  AND expires_at > NOW();
+
+-- name: UpsertGitHubUserCache :one
+INSERT INTO github_user_cache (author_email, github_username, expires_at)
+VALUES (
+    LOWER(BTRIM(sqlc.arg('author_email'))),
+    sqlc.narg('github_username'),
+    sqlc.arg('expires_at')
+)
+ON CONFLICT (author_email) DO UPDATE SET
+    github_username = EXCLUDED.github_username,
+    expires_at = EXCLUDED.expires_at,
+    updated_at = NOW()
+RETURNING *;
+
 -- name: CreateArtifactVersionTag :one
 INSERT INTO artifact_versioned_tags (artifact_version_id, tag_key, tag_value)
 VALUES ($1, $2, $3)

--- a/db/query.sql
+++ b/db/query.sql
@@ -165,19 +165,21 @@ SELECT * FROM artifact_versions
 WHERE id = $1
 FOR UPDATE;
 
+-- The predicate must stay identical to idx_versions_github_authors_unresolved,
+-- including the literal schema version, or the partial index is not used.
+-- Guarded by TestAuthorResolutionSchemaMatchesSQL.
 -- name: ListVersionsNeedingGitHubAuthorResolution :many
 SELECT id
 FROM artifact_versions
-WHERE commit_body IS NOT NULL
-  AND commit_body->>'enrichedAt' IS NOT NULL
-  AND commit_body->>'githubAuthorsResolvedAt' IS NULL
+WHERE commit_body->>'enrichedAt' IS NOT NULL
+  AND (commit_body->'authorResolution'->>'schema') IS DISTINCT FROM '1'
   AND (sqlc.narg('before_id')::bigint IS NULL OR id < sqlc.narg('before_id'))
 ORDER BY id DESC
 LIMIT sqlc.arg('page_size');
 
--- name: GetGitHubUserCache :one
+-- name: GetGitHubUserCacheBatch :many
 SELECT * FROM github_user_cache
-WHERE author_email = LOWER(BTRIM(sqlc.arg('author_email')))
+WHERE author_email = ANY(sqlc.arg('author_emails')::text[])
   AND expires_at > NOW();
 
 -- name: UpsertGitHubUserCache :one

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -45,8 +45,19 @@ CREATE TABLE artifact_versioned_tags (
     PRIMARY KEY (artifact_version_id, tag_key)
 );
 
+CREATE TABLE github_user_cache (
+    author_email TEXT PRIMARY KEY,
+    github_username TEXT,
+    expires_at TIMESTAMPTZ NOT NULL,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
 CREATE INDEX idx_versioned_tags_key_value ON artifact_versioned_tags(tag_key, tag_value, artifact_version_id);
 CREATE INDEX idx_versioned_tags_av_key_value ON artifact_versioned_tags(artifact_version_id, tag_key, tag_value);
 CREATE INDEX idx_versioned_assets_version_id ON artifact_versioned_assets(artifact_version_id);
 CREATE INDEX idx_versions_artifact_sort ON artifact_versions(artifact_id, sort_order DESC);
 CREATE INDEX idx_versions_artifact_recommended_sort ON artifact_versions(artifact_id, recommended, sort_order DESC);
+CREATE INDEX idx_github_user_cache_expires_at ON github_user_cache(expires_at);
+CREATE INDEX idx_versions_github_authors_unresolved ON artifact_versions(id DESC)
+WHERE commit_body->>'enrichedAt' IS NOT NULL
+  AND commit_body->>'githubAuthorsResolvedAt' IS NULL;

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -57,7 +57,9 @@ CREATE INDEX idx_versioned_tags_av_key_value ON artifact_versioned_tags(artifact
 CREATE INDEX idx_versioned_assets_version_id ON artifact_versioned_assets(artifact_version_id);
 CREATE INDEX idx_versions_artifact_sort ON artifact_versions(artifact_id, sort_order DESC);
 CREATE INDEX idx_versions_artifact_recommended_sort ON artifact_versions(artifact_id, recommended, sort_order DESC);
-CREATE INDEX idx_github_user_cache_expires_at ON github_user_cache(expires_at);
+-- The literal schema version is duplicated by
+-- ListVersionsNeedingGitHubAuthorResolution and guarded by
+-- TestAuthorResolutionSchemaMatchesSQL.
 CREATE INDEX idx_versions_github_authors_unresolved ON artifact_versions(id DESC)
 WHERE commit_body->>'enrichedAt' IS NOT NULL
-  AND commit_body->>'githubAuthorsResolvedAt' IS NULL;
+  AND (commit_body->'authorResolution'->>'schema') IS DISTINCT FROM '1';

--- a/docs/WORKFLOWS.md
+++ b/docs/WORKFLOWS.md
@@ -53,7 +53,7 @@ GitHub author resolution runs independently from ingestion:
 
 ```
 GitHubAuthorResolutionWorkflow (singleton schedule, every 2m)
- ├── FetchGitHubAuthorResolutionPage (DB: newest unresolved 50 IDs)
+ ├── FetchVersionsNeedingAuthorResolution (DB: newest 50 IDs, marker missing or stale)
  ├── ResolveGitHubAuthorsBatch (one heartbeat-enabled keyset page)
  │    ├── infer usernames from GitHub noreply email addresses
  │    ├── read/write the persistent github_user_cache
@@ -231,10 +231,13 @@ The server ensures one global Temporal Schedule exists:
 | Setting | Value |
 |---------|-------|
 | Schedule ID | `github-author-resolution` |
-| Interval | 2 minutes |
+| Interval | 2 minutes (±15s jitter) |
 | Overlap policy | `SKIP` |
+| Workflow execution timeout | 2 hours |
 | Task queue | `version-sync` |
 | Initial state | Paused |
+
+The execution timeout bounds an entire `ContinueAsNew` chain, not a single page, so a wedged backfill is abandoned and restarted from the newest page instead of running forever behind a `SKIP` that would hide every later tick.
 
 The schedule is created paused so a deployment can apply migration `000006_github_author_resolution`, configure `GITHUB_TOKEN`, and confirm the worker is running before beginning the historical backfill. Public repositories can be queried without a token, but authenticated requests have higher rate limits and can access repositories visible to that token.
 
@@ -258,16 +261,27 @@ temporal schedule pause \
 
 Each workflow chain scans enriched versions newest-first in 50-row keyset pages. The page is dispatched as one batch activity, then the workflow uses `ContinueAsNew` with the oldest ID as its cursor. The chain drains the entire unresolved history and ends when it reaches an empty page; the next scheduled fire starts from the newest unresolved row again.
 
-Resolution covers the head commit, direct submodule commits, the main changelog, and recursively nested submodule changelogs. Usernames embedded in GitHub noreply email addresses are resolved locally. Other authors use the GitHub commit API and a PostgreSQL cache:
+Resolution covers the head commit, direct submodule commits, the main changelog, and recursively nested submodule changelogs. The batch activity reads every version in the page without locking, deduplicates authors across the whole page, and serves them from `github_user_cache` in a single `WHERE author_email = ANY(...)` query. Only the remaining misses reach GitHub, so a page normally costs no API calls at all. Usernames embedded in GitHub noreply email addresses are parsed locally and never consume a lookup or a cache row.
 
-- Positive cache entries expire after 30 days.
-- Negative cache entries expire after 6 hours.
+- Cache entries expire after 30 days, hits and misses alike; "GitHub has no account for this address" is as stable an answer as a username.
 - Cache keys are normalized lowercase author email addresses.
-- Authors without an email can be resolved for the current version but are not persisted in the email cache.
+- Authors without an email are deduplicated by commit for the current run only, and are not persisted in the email cache.
 
-After all authors for a version are resolved, the activity locks that `artifact_versions` row with `SELECT ... FOR UPDATE`, re-reads the latest JSONB value, merges usernames, and sets `githubAuthorsResolvedAt`. Changelog writes use the same row lock and clear this marker because a recomputed changelog may contain new unresolved authors.
+Only once all GitHub work for the page is finished does the activity lock each `artifact_versions` row with `SELECT ... FOR UPDATE`, re-read the latest JSONB value, merge usernames, and stamp the marker. No row lock is ever held across a GitHub call. Changelog writes use the same row lock and clear the marker, because a recomputed changelog may contain new unresolved authors.
 
-The resolution activity records the next version index in a Temporal heartbeat and continues heartbeating while processing that version's authors. An activity retry resumes within the page rather than repeating completed versions. Transient failures (database or GitHub errors) fail the activity so Temporal retries it, up to three attempts, before the run fails and the next scheduled tick starts a fresh chain. No marker is stamped, so nothing is lost. Versions that can never resolve (row deleted, or a `commit_body` that no longer parses) are logged and skipped so a single bad row cannot stall the backfill. GitHub rate-limit responses use `X-RateLimit-Reset` to set Temporal's next retry delay.
+The marker is an `authorResolution` object rather than a bare timestamp:
+
+```json
+{ "at": "2026-07-27T01:00:00Z", "unresolved": 3, "schema": 1 }
+```
+
+`unresolved` counts author entries with no associated GitHub account. `schema` is the version of the resolution logic that produced the result, so the keyset query selects versions whose marker is **missing or stale**. Raising `domain.AuthorResolutionSchema` therefore re-resolves the entire history on the next unpaused run. Because a partial index predicate cannot be parameterised, the schema version is a literal in both `db/query.sql` and `idx_versions_github_authors_unresolved`; bumping it requires a migration that replaces that index, or the keyset scan silently stops being indexed.
+
+The resolution activity records the next version index in a Temporal heartbeat, so an activity retry resumes within the page rather than repeating completed versions. Every GitHub result is written to the shared cache as soon as it is known, which means a resumed attempt re-reads earlier answers from the cache instead of paying for them twice.
+
+Transient failures (database or GitHub errors) fail the activity so Temporal retries it, up to five attempts within a 10 minute schedule-to-close budget. If that is exhausted the run fails and the next scheduled tick starts a fresh chain; no marker is stamped, so nothing is lost. Versions that can never resolve (row deleted, or a `commit_body` that no longer parses) are logged and skipped, so a single bad row cannot stall the backfill. GitHub rate-limit responses use `X-RateLimit-Reset` to set Temporal's next retry delay.
+
+The activity returns counts only — versions stamped, authors resolved, authors unresolved — so commit bodies never enter workflow history.
 
 ## On-Demand Sync Trigger
 
@@ -421,8 +435,8 @@ All activity structs are registered on the worker via `w.RegisterActivity(struct
 | Git clone/fetch (local) | 2m | 3 | Large repos may take time to clone |
 | Git read operations (local) | 30s | 3 | git show, git log, git ls-tree |
 | Changelog DB activities | 30s | 3 | Standard DB reads/writes |
-| GitHub author page fetch | 30s | 3 | Keyset query for unresolved enriched versions |
-| GitHub author batch | 10m | 3 | Heartbeats every completed version; rate limits override the next retry delay |
+| GitHub author page fetch | 30s | 3 | Keyset query for versions whose marker is missing or stale |
+| GitHub author batch | 1m per attempt, 10m schedule-to-close | 5 | Heartbeats per resolved author and per stamped version; rate limits override the next retry delay |
 
 All use exponential backoff (initial 1-2s, coefficient 2.0, max 30s-1m).
 

--- a/docs/WORKFLOWS.md
+++ b/docs/WORKFLOWS.md
@@ -1,6 +1,6 @@
 # Temporal Workflows
 
-SystemOfADownload uses [Temporal](https://temporal.io/) to orchestrate artifact version syncing, asset indexing, commit extraction, and version ordering. All workflows run on a single task queue (`version-sync`) with a single worker process.
+SystemOfADownload uses [Temporal](https://temporal.io/) to orchestrate artifact version syncing, asset indexing, commit extraction, version ordering, and GitHub author resolution. All workflows run on a single task queue (`version-sync`) with a single worker process.
 
 ## Architecture Overview
 
@@ -37,7 +37,7 @@ VersionSyncWorkflow ────────────────────
       │         ├── [per submodule, parallel]                         |
       │         │    ├── EnsureRepoCloned  (local: submodule repo)   |
       │         │    └── GetCommitDetails  (local: submodule SHA)    |
-      │         └── StoreEnrichedCommit    (GitHub author lookup + DB)|
+      │         └── StoreEnrichedCommit    (DB)                      |
       └── ChangelogBatchWorkflow   (sequential, sort_order ASC)      |
            └── ChangelogVersionWorkflow (per version)                 |
                 ├── GetPreviousVersionCommit (DB)                     |
@@ -45,9 +45,24 @@ VersionSyncWorkflow ────────────────────
                 ├── ComputeChangelog       (local: git log)           |
                 ├── [per submodule with changed pointer]              |
                 │    └── ComputeChangelog  (local: submodule log)     |
-                └── StoreChangelog         (GitHub author lookup + DB)|
+                └── StoreChangelog         (DB)                       |
 ──────────────────────────────────────────────────────────────────────┘
 ```
+
+GitHub author resolution runs independently from ingestion:
+
+```
+GitHubAuthorResolutionWorkflow (singleton schedule, every 2m)
+ ├── FetchGitHubAuthorResolutionPage (DB: newest unresolved 50 IDs)
+ ├── ResolveGitHubAuthorsBatch (one heartbeat-enabled keyset page)
+ │    ├── infer usernames from GitHub noreply email addresses
+ │    ├── read/write the persistent github_user_cache
+ │    ├── query the GitHub commit API when needed
+ │    └── lock and merge artifact_versions.commit_body (JSONB)
+ └── ContinueAsNew with the next keyset cursor
+```
+
+Keeping this workflow separate means Sonatype ingestion and git enrichment remain pure database/local-git operations. A GitHub outage or rate limit delays username resolution without delaying version ingestion, and unresolved historical rows are retried by later scheduled runs.
 
 ## Worker Deployment Versioning
 
@@ -133,15 +148,6 @@ Processes a single version: fetches assets from Sonatype, stores them, identifie
 
 Downloads jar files and parses `META-INF/git.properties` or `META-INF/MANIFEST.MF` to extract git commit SHAs and repository URLs. Uses the same sliding window pattern as batch indexing (window size 3, page size 5).
 
-During commit and changelog persistence, GitHub-hosted commits are resolved to
-their associated GitHub username. GitHub noreply addresses are handled locally;
-other addresses use the GitHub commit API. The username is stored alongside the
-Git author name and email, while lookup failures retain the Git name fallback.
-`StoreChangelog` has a two-minute activity timeout to accommodate bounded,
-parallel lookups across large changelogs. GitHub lookups stop five seconds
-before the activity deadline so optional enrichment cannot consume the time
-needed for the database write.
-
 ### VersionOrderingWorkflow
 
 Computes version sort ordering using schema-driven parsing and optionally the Mojang version manifest for correct Minecraft version placement.
@@ -216,6 +222,53 @@ When an artifact is registered, **two** Temporal Schedules are created to period
 
 **Legacy schedule ID:** before the dual-schedule rollout, schedules were named `version-sync-{groupID}-{artifactID}`. Existing namespaces need the temporal CLI commands in the runbook section below to convert.
 
+## GitHub Author Resolution
+
+`GitHubAuthorResolutionWorkflow` backfills and maintains the optional `githubUsername` fields stored inside `artifact_versions.commit_body`. The HTTP API and frontend prefer that username and link to the matching GitHub profile; the original git author name remains the fallback.
+
+The server ensures one global Temporal Schedule exists:
+
+| Setting | Value |
+|---------|-------|
+| Schedule ID | `github-author-resolution` |
+| Interval | 2 minutes |
+| Overlap policy | `SKIP` |
+| Task queue | `version-sync` |
+| Initial state | Paused |
+
+The schedule is created paused so a deployment can apply migration `000006_github_author_resolution`, configure `GITHUB_TOKEN`, and confirm the worker is running before beginning the historical backfill. Public repositories can be queried without a token, but authenticated requests have higher rate limits and can access repositories visible to that token.
+
+Unpause the schedule after rollout:
+
+```bash
+temporal schedule unpause \
+  --schedule-id github-author-resolution \
+  --namespace <namespace> \
+  --address <host>
+```
+
+Pause it again without losing progress:
+
+```bash
+temporal schedule pause \
+  --schedule-id github-author-resolution \
+  --namespace <namespace> \
+  --address <host>
+```
+
+Each workflow chain scans enriched versions newest-first in 50-row keyset pages. The page is dispatched as one batch activity, then the workflow uses `ContinueAsNew` with the oldest ID as its cursor. The chain drains the entire unresolved history and ends when it reaches an empty page; the next scheduled fire starts from the newest unresolved row again.
+
+Resolution covers the head commit, direct submodule commits, the main changelog, and recursively nested submodule changelogs. Usernames embedded in GitHub noreply email addresses are resolved locally. Other authors use the GitHub commit API and a PostgreSQL cache:
+
+- Positive cache entries expire after 30 days.
+- Negative cache entries expire after 6 hours.
+- Cache keys are normalized lowercase author email addresses.
+- Authors without an email can be resolved for the current version but are not persisted in the email cache.
+
+After all authors for a version are resolved, the activity locks that `artifact_versions` row with `SELECT ... FOR UPDATE`, re-reads the latest JSONB value, merges usernames, and sets `githubAuthorsResolvedAt`. Changelog writes use the same row lock and clear this marker because a recomputed changelog may contain new unresolved authors.
+
+The resolution activity records the next version index in a Temporal heartbeat and continues heartbeating while processing that version's authors. An activity retry resumes within the page rather than repeating completed versions. Failures retry up to three attempts; after the final attempt that version remains unmarked and the batch continues. GitHub rate-limit responses use `X-RateLimit-Reset` to set Temporal's next retry delay.
+
 ## On-Demand Sync Trigger
 
 The `POST /groups/{groupID}/artifacts/{artifactID}/sync` endpoint triggers a schedule immediately. The query parameter `source` chooses which schedule to fire:
@@ -260,6 +313,7 @@ jobs:
 |---------|----------|----------------|----------|
 | Fast schedule (2m) | VersionSyncWorkflow | `BUFFER_ONE` | Queue one run if current sync still running |
 | Full schedule (1h) | VersionSyncWorkflow | `SKIP` | Drop the tick if a previous full run is still going |
+| GitHub author schedule (2m) | GitHubAuthorResolutionWorkflow | `SKIP` | Drop the tick while the singleton backfill/resolution chain is still running |
 | `POST .../sync` | VersionSyncWorkflow | — | Fires target schedule (default: fast; `?source=search` for full) |
 | `PutArtifactSchema` | VersionOrderingWorkflow | `TERMINATE_EXISTING` | Cancel stale run, restart with new schema |
 
@@ -352,6 +406,7 @@ Activities are grouped into structs by responsibility, each with explicit depend
 | `VersionIndexActivities` | Sonatype client, Repository, HTTP client | Fetch/store assets, inspect jars, extract commits |
 | `VersionOrderingActivities` | Repository, HTTP client | Schema loading, manifest fetching, ordering, tag storage |
 | `ChangelogActivities` | Repository | Fetch versions for enrichment, store enriched commits, store changelogs |
+| `GitHubAuthorResolutionActivities` | Repository, GitHub client | Discover unresolved versions, cache author lookups, and merge usernames |
 | `GitActivities` | GitCacheManager | Local activities: clone/fetch repos, git show, resolve submodules, git log |
 
 All activity structs are registered on the worker via `w.RegisterActivity(struct)`, which auto-registers all exported methods.
@@ -366,6 +421,8 @@ All activity structs are registered on the worker via `w.RegisterActivity(struct
 | Git clone/fetch (local) | 2m | 3 | Large repos may take time to clone |
 | Git read operations (local) | 30s | 3 | git show, git log, git ls-tree |
 | Changelog DB activities | 30s | 3 | Standard DB reads/writes |
+| GitHub author page fetch | 30s | 3 | Keyset query for unresolved enriched versions |
+| GitHub author batch | 10m | 3 | Heartbeats every completed version; rate limits override the next retry delay |
 
 All use exponential backoff (initial 1-2s, coefficient 2.0, max 30s-1m).
 

--- a/docs/WORKFLOWS.md
+++ b/docs/WORKFLOWS.md
@@ -267,7 +267,7 @@ Resolution covers the head commit, direct submodule commits, the main changelog,
 
 After all authors for a version are resolved, the activity locks that `artifact_versions` row with `SELECT ... FOR UPDATE`, re-reads the latest JSONB value, merges usernames, and sets `githubAuthorsResolvedAt`. Changelog writes use the same row lock and clear this marker because a recomputed changelog may contain new unresolved authors.
 
-The resolution activity records the next version index in a Temporal heartbeat and continues heartbeating while processing that version's authors. An activity retry resumes within the page rather than repeating completed versions. Failures retry up to three attempts; after the final attempt that version remains unmarked and the batch continues. GitHub rate-limit responses use `X-RateLimit-Reset` to set Temporal's next retry delay.
+The resolution activity records the next version index in a Temporal heartbeat and continues heartbeating while processing that version's authors. An activity retry resumes within the page rather than repeating completed versions. Transient failures (database or GitHub errors) fail the activity so Temporal retries it, up to three attempts, before the run fails and the next scheduled tick starts a fresh chain. No marker is stamped, so nothing is lost. Versions that can never resolve (row deleted, or a `commit_body` that no longer parses) are logged and skipped so a single bad row cannot stall the backfill. GitHub rate-limit responses use `X-RateLimit-Reset` to set Temporal's next retry delay.
 
 ## On-Demand Sync Trigger
 

--- a/docs/WORKFLOWS.md
+++ b/docs/WORKFLOWS.md
@@ -37,7 +37,7 @@ VersionSyncWorkflow ────────────────────
       │         ├── [per submodule, parallel]                         |
       │         │    ├── EnsureRepoCloned  (local: submodule repo)   |
       │         │    └── GetCommitDetails  (local: submodule SHA)    |
-      │         └── StoreEnrichedCommit    (DB)                      |
+      │         └── StoreEnrichedCommit    (GitHub author lookup + DB)|
       └── ChangelogBatchWorkflow   (sequential, sort_order ASC)      |
            └── ChangelogVersionWorkflow (per version)                 |
                 ├── GetPreviousVersionCommit (DB)                     |
@@ -45,7 +45,7 @@ VersionSyncWorkflow ────────────────────
                 ├── ComputeChangelog       (local: git log)           |
                 ├── [per submodule with changed pointer]              |
                 │    └── ComputeChangelog  (local: submodule log)     |
-                └── StoreChangelog         (DB)                       |
+                └── StoreChangelog         (GitHub author lookup + DB)|
 ──────────────────────────────────────────────────────────────────────┘
 ```
 
@@ -56,6 +56,7 @@ The worker uses Temporal's [Worker Deployment Versioning](https://docs.temporal.
 **Configuration (env vars):**
 - `BUILD_ID` (required) — image tag or version identifier, set by the deployment pipeline. The worker will refuse to start if this is empty.
 - `POD_NAME` (optional) — Kubernetes pod name, used as the Temporal client `Identity` for traceability in the Temporal UI.
+- `GITHUB_TOKEN` (optional) — authenticates commit-author lookups for higher API limits and private repositories. Public GitHub repositories are queried without authentication when unset.
 
 **Worker registration:**
 ```go
@@ -131,6 +132,15 @@ Processes a single version: fetches assets from Sonatype, stores them, identifie
 ### ExtractCommitBatchWorkflow / ExtractCommitWorkflow
 
 Downloads jar files and parses `META-INF/git.properties` or `META-INF/MANIFEST.MF` to extract git commit SHAs and repository URLs. Uses the same sliding window pattern as batch indexing (window size 3, page size 5).
+
+During commit and changelog persistence, GitHub-hosted commits are resolved to
+their associated GitHub username. GitHub noreply addresses are handled locally;
+other addresses use the GitHub commit API. The username is stored alongside the
+Git author name and email, while lookup failures retain the Git name fallback.
+`StoreChangelog` has a two-minute activity timeout to accommodate bounded,
+parallel lookups across large changelogs. GitHub lookups stop five seconds
+before the activity deadline so optional enrichment cannot consume the time
+needed for the database write.
 
 ### VersionOrderingWorkflow
 

--- a/internal/activity/changelog_activities.go
+++ b/internal/activity/changelog_activities.go
@@ -241,7 +241,7 @@ func (a *ChangelogActivities) StoreChangelog(ctx context.Context, input StoreCha
 		info.Changelog = &input.Changelog
 		// A recomputed changelog introduces a fresh author set. Clear the
 		// marker so the durable resolver revisits this version.
-		info.GitHubAuthorsResolvedAt = ""
+		info.AuthorResolution = nil
 		// Only clear pending_predecessor status; preserve error statuses
 		// (e.g., error_commit_not_found from Phase 1).
 		if info.ChangelogStatus == "pending_predecessor" {

--- a/internal/activity/changelog_activities.go
+++ b/internal/activity/changelog_activities.go
@@ -4,21 +4,16 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"log/slog"
-	"sync"
-	"time"
 
 	"github.com/spongepowered/systemofadownload/internal/db"
 	"github.com/spongepowered/systemofadownload/internal/domain"
-	"github.com/spongepowered/systemofadownload/internal/githubapi"
 	"github.com/spongepowered/systemofadownload/internal/repository"
 )
 
 // ChangelogActivities provides normal (non-local) activities for
 // commit enrichment DB reads and writes.
 type ChangelogActivities struct {
-	Repo   repository.Repository
-	GitHub *githubapi.Client
+	Repo repository.Repository
 }
 
 // FetchVersionsForEnrichmentInput is the input for FetchVersionsForEnrichment.
@@ -208,8 +203,6 @@ type StoreEnrichedCommitInput struct {
 
 // StoreEnrichedCommit writes the enriched commit info back to the DB.
 func (a *ChangelogActivities) StoreEnrichedCommit(ctx context.Context, input StoreEnrichedCommitInput) error { //nolint:gocritic // Temporal activity signature requires value type
-	a.resolveCommitInfoAuthors(ctx, &input.CommitInfo)
-
 	data, err := json.Marshal(input.CommitInfo)
 	if err != nil {
 		return fmt.Errorf("marshaling enriched commit: %w", err)
@@ -232,10 +225,8 @@ type StoreChangelogInput struct {
 // StoreChangelog reads the current commit_body, merges the changelog into it,
 // and writes it back. This preserves the enrichment data already stored.
 func (a *ChangelogActivities) StoreChangelog(ctx context.Context, input StoreChangelogInput) error {
-	a.resolveChangelogAuthors(ctx, &input.Changelog)
-
 	return a.Repo.WithTx(ctx, func(tx repository.Tx) error {
-		av, err := tx.GetArtifactVersionByID(ctx, input.VersionID)
+		av, err := tx.GetArtifactVersionForUpdate(ctx, input.VersionID)
 		if err != nil {
 			return fmt.Errorf("reading version %d: %w", input.VersionID, err)
 		}
@@ -248,6 +239,9 @@ func (a *ChangelogActivities) StoreChangelog(ctx context.Context, input StoreCha
 		}
 
 		info.Changelog = &input.Changelog
+		// A recomputed changelog introduces a fresh author set. Clear the
+		// marker so the durable resolver revisits this version.
+		info.GitHubAuthorsResolvedAt = ""
 		// Only clear pending_predecessor status; preserve error statuses
 		// (e.g., error_commit_not_found from Phase 1).
 		if info.ChangelogStatus == "pending_predecessor" {
@@ -264,138 +258,4 @@ func (a *ChangelogActivities) StoreChangelog(ctx context.Context, input StoreCha
 			CommitBody: data,
 		})
 	})
-}
-
-type authorLookup struct {
-	author     *domain.CommitAuthor
-	repository string
-	sha        string
-}
-
-func (a *ChangelogActivities) resolveCommitInfoAuthors(ctx context.Context, info *domain.CommitInfo) {
-	lookups := []authorLookup{{
-		author:     info.Author,
-		repository: info.Repository,
-		sha:        info.Sha,
-	}}
-	for i := range info.Submodules {
-		lookups = append(lookups, authorLookup{
-			author:     info.Submodules[i].Author,
-			repository: info.Submodules[i].Repository,
-			sha:        info.Submodules[i].Sha,
-		})
-	}
-	a.resolveAuthors(ctx, lookups)
-}
-
-func (a *ChangelogActivities) resolveChangelogAuthors(ctx context.Context, changelog *domain.Changelog) {
-	var lookups []authorLookup
-	collectChangelogAuthorLookups(changelog, "", &lookups)
-	a.resolveAuthors(ctx, lookups)
-}
-
-func collectChangelogAuthorLookups(changelog *domain.Changelog, repoURL string, lookups *[]authorLookup) {
-	if changelog == nil {
-		return
-	}
-	for i := range changelog.Commits {
-		commit := &changelog.Commits[i]
-		commitRepo := repoURL
-		if owner, repo, ok := githubapi.ParseRepository(commit.URL); ok {
-			commitRepo = "https://github.com/" + owner + "/" + repo
-		}
-		*lookups = append(*lookups, authorLookup{
-			author:     commit.Author,
-			repository: commitRepo,
-			sha:        commit.Sha,
-		})
-	}
-	for subRepo, subChangelog := range changelog.SubmoduleChangelogs {
-		collectChangelogAuthorLookups(subChangelog, subRepo, lookups)
-	}
-}
-
-func (a *ChangelogActivities) resolveAuthors(ctx context.Context, lookups []authorLookup) {
-	if a.GitHub == nil || len(lookups) == 0 {
-		return
-	}
-
-	lookupCtx, cancel, ok := githubLookupContext(ctx)
-	if !ok {
-		slog.WarnContext(ctx, "skipping GitHub author lookup to preserve database persistence time")
-		return
-	}
-	defer cancel()
-
-	const concurrency = 4
-	sem := make(chan struct{}, concurrency)
-	var wg sync.WaitGroup
-	var errorCount int
-	var firstErr error
-	var errorMu sync.Mutex
-
-	for i := range lookups {
-		lookup := lookups[i]
-		if lookup.author == nil || lookup.author.GitHubUsername != "" {
-			continue
-		}
-
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			select {
-			case sem <- struct{}{}:
-			case <-lookupCtx.Done():
-				errorMu.Lock()
-				errorCount++
-				if firstErr == nil {
-					firstErr = lookupCtx.Err()
-				}
-				errorMu.Unlock()
-				return
-			}
-			defer func() { <-sem }()
-
-			username, err := a.GitHub.ResolveUsername(
-				lookupCtx,
-				lookup.repository,
-				lookup.sha,
-				lookup.author.Email,
-			)
-			if err != nil {
-				errorMu.Lock()
-				errorCount++
-				if firstErr == nil {
-					firstErr = err
-				}
-				errorMu.Unlock()
-				return
-			}
-			lookup.author.GitHubUsername = username
-		}()
-	}
-	wg.Wait()
-
-	if errorCount > 0 {
-		slog.WarnContext(ctx, "GitHub author lookup failed; using Git author names",
-			"failures", errorCount,
-			"error", firstErr,
-		)
-	}
-}
-
-const githubLookupPersistenceReserve = 5 * time.Second
-
-func githubLookupContext(ctx context.Context) (context.Context, context.CancelFunc, bool) {
-	if deadline, ok := ctx.Deadline(); ok {
-		lookupDeadline := deadline.Add(-githubLookupPersistenceReserve)
-		if !time.Now().Before(lookupDeadline) {
-			return nil, nil, false
-		}
-		lookupCtx, cancel := context.WithDeadline(ctx, lookupDeadline)
-		return lookupCtx, cancel, true
-	}
-
-	lookupCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
-	return lookupCtx, cancel, true
 }

--- a/internal/activity/changelog_activities.go
+++ b/internal/activity/changelog_activities.go
@@ -4,16 +4,21 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log/slog"
+	"sync"
+	"time"
 
 	"github.com/spongepowered/systemofadownload/internal/db"
 	"github.com/spongepowered/systemofadownload/internal/domain"
+	"github.com/spongepowered/systemofadownload/internal/githubapi"
 	"github.com/spongepowered/systemofadownload/internal/repository"
 )
 
 // ChangelogActivities provides normal (non-local) activities for
 // commit enrichment DB reads and writes.
 type ChangelogActivities struct {
-	Repo repository.Repository
+	Repo   repository.Repository
+	GitHub *githubapi.Client
 }
 
 // FetchVersionsForEnrichmentInput is the input for FetchVersionsForEnrichment.
@@ -203,6 +208,8 @@ type StoreEnrichedCommitInput struct {
 
 // StoreEnrichedCommit writes the enriched commit info back to the DB.
 func (a *ChangelogActivities) StoreEnrichedCommit(ctx context.Context, input StoreEnrichedCommitInput) error { //nolint:gocritic // Temporal activity signature requires value type
+	a.resolveCommitInfoAuthors(ctx, &input.CommitInfo)
+
 	data, err := json.Marshal(input.CommitInfo)
 	if err != nil {
 		return fmt.Errorf("marshaling enriched commit: %w", err)
@@ -225,6 +232,8 @@ type StoreChangelogInput struct {
 // StoreChangelog reads the current commit_body, merges the changelog into it,
 // and writes it back. This preserves the enrichment data already stored.
 func (a *ChangelogActivities) StoreChangelog(ctx context.Context, input StoreChangelogInput) error {
+	a.resolveChangelogAuthors(ctx, &input.Changelog)
+
 	return a.Repo.WithTx(ctx, func(tx repository.Tx) error {
 		av, err := tx.GetArtifactVersionByID(ctx, input.VersionID)
 		if err != nil {
@@ -255,4 +264,138 @@ func (a *ChangelogActivities) StoreChangelog(ctx context.Context, input StoreCha
 			CommitBody: data,
 		})
 	})
+}
+
+type authorLookup struct {
+	author     *domain.CommitAuthor
+	repository string
+	sha        string
+}
+
+func (a *ChangelogActivities) resolveCommitInfoAuthors(ctx context.Context, info *domain.CommitInfo) {
+	lookups := []authorLookup{{
+		author:     info.Author,
+		repository: info.Repository,
+		sha:        info.Sha,
+	}}
+	for i := range info.Submodules {
+		lookups = append(lookups, authorLookup{
+			author:     info.Submodules[i].Author,
+			repository: info.Submodules[i].Repository,
+			sha:        info.Submodules[i].Sha,
+		})
+	}
+	a.resolveAuthors(ctx, lookups)
+}
+
+func (a *ChangelogActivities) resolveChangelogAuthors(ctx context.Context, changelog *domain.Changelog) {
+	var lookups []authorLookup
+	collectChangelogAuthorLookups(changelog, "", &lookups)
+	a.resolveAuthors(ctx, lookups)
+}
+
+func collectChangelogAuthorLookups(changelog *domain.Changelog, repoURL string, lookups *[]authorLookup) {
+	if changelog == nil {
+		return
+	}
+	for i := range changelog.Commits {
+		commit := &changelog.Commits[i]
+		commitRepo := repoURL
+		if owner, repo, ok := githubapi.ParseRepository(commit.URL); ok {
+			commitRepo = "https://github.com/" + owner + "/" + repo
+		}
+		*lookups = append(*lookups, authorLookup{
+			author:     commit.Author,
+			repository: commitRepo,
+			sha:        commit.Sha,
+		})
+	}
+	for subRepo, subChangelog := range changelog.SubmoduleChangelogs {
+		collectChangelogAuthorLookups(subChangelog, subRepo, lookups)
+	}
+}
+
+func (a *ChangelogActivities) resolveAuthors(ctx context.Context, lookups []authorLookup) {
+	if a.GitHub == nil || len(lookups) == 0 {
+		return
+	}
+
+	lookupCtx, cancel, ok := githubLookupContext(ctx)
+	if !ok {
+		slog.WarnContext(ctx, "skipping GitHub author lookup to preserve database persistence time")
+		return
+	}
+	defer cancel()
+
+	const concurrency = 4
+	sem := make(chan struct{}, concurrency)
+	var wg sync.WaitGroup
+	var errorCount int
+	var firstErr error
+	var errorMu sync.Mutex
+
+	for i := range lookups {
+		lookup := lookups[i]
+		if lookup.author == nil || lookup.author.GitHubUsername != "" {
+			continue
+		}
+
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			select {
+			case sem <- struct{}{}:
+			case <-lookupCtx.Done():
+				errorMu.Lock()
+				errorCount++
+				if firstErr == nil {
+					firstErr = lookupCtx.Err()
+				}
+				errorMu.Unlock()
+				return
+			}
+			defer func() { <-sem }()
+
+			username, err := a.GitHub.ResolveUsername(
+				lookupCtx,
+				lookup.repository,
+				lookup.sha,
+				lookup.author.Email,
+			)
+			if err != nil {
+				errorMu.Lock()
+				errorCount++
+				if firstErr == nil {
+					firstErr = err
+				}
+				errorMu.Unlock()
+				return
+			}
+			lookup.author.GitHubUsername = username
+		}()
+	}
+	wg.Wait()
+
+	if errorCount > 0 {
+		slog.WarnContext(ctx, "GitHub author lookup failed; using Git author names",
+			"failures", errorCount,
+			"error", firstErr,
+		)
+	}
+}
+
+const githubLookupPersistenceReserve = 5 * time.Second
+
+func githubLookupContext(ctx context.Context) (context.Context, context.CancelFunc, bool) {
+	if deadline, ok := ctx.Deadline(); ok {
+		lookupDeadline := deadline.Add(-githubLookupPersistenceReserve)
+		if !time.Now().Before(lookupDeadline) {
+			return nil, nil, false
+		}
+		lookupCtx, cancel := context.WithDeadline(ctx, lookupDeadline)
+		return lookupCtx, cancel, true
+	}
+
+	lookupCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	return lookupCtx, cancel, true
 }

--- a/internal/activity/changelog_activities_test.go
+++ b/internal/activity/changelog_activities_test.go
@@ -218,13 +218,13 @@ func TestStoreChangelogLocksVersionBeforeMerge(t *testing.T) {
 	tx.EXPECT().GetArtifactVersionForUpdate(mock.Anything, int64(10)).
 		Return(db.ArtifactVersion{
 			ID:         10,
-			CommitBody: []byte(`{"sha":"abc","enrichedAt":"2026-07-27T00:00:00Z","githubAuthorsResolvedAt":"2026-07-27T01:00:00Z"}`),
+			CommitBody: []byte(`{"sha":"abc","enrichedAt":"2026-07-27T00:00:00Z","authorResolution":{"at":"2026-07-27T01:00:00Z","unresolved":0,"schema":1}}`),
 		}, nil)
 	tx.EXPECT().UpdateArtifactVersionCommitBody(mock.Anything, mock.MatchedBy(
 		func(params db.UpdateArtifactVersionCommitBodyParams) bool {
 			var info domain.CommitInfo
 			return json.Unmarshal(params.CommitBody, &info) == nil &&
-				info.GitHubAuthorsResolvedAt == ""
+				info.AuthorResolution == nil
 		},
 	)).Return(nil)
 

--- a/internal/activity/changelog_activities_test.go
+++ b/internal/activity/changelog_activities_test.go
@@ -1,15 +1,22 @@
 package activity_test
 
 import (
+	"context"
 	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/jackc/pgx/v5"
+	"github.com/stretchr/testify/mock"
 
 	"github.com/spongepowered/systemofadownload/internal/activity"
 	"github.com/spongepowered/systemofadownload/internal/db"
 	"github.com/spongepowered/systemofadownload/internal/domain"
+	"github.com/spongepowered/systemofadownload/internal/githubapi"
+	"github.com/spongepowered/systemofadownload/internal/repository"
 	repomocks "github.com/spongepowered/systemofadownload/internal/repository/mocks"
 )
 
@@ -199,5 +206,178 @@ func TestCheckPreviousVersionEnriched(t *testing.T) {
 	}
 	if enriched {
 		t.Error("expected enriched=false for version 11")
+	}
+}
+
+func TestStoreCommitDataResolvesGitHubUsernames(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		run        func(context.Context, *activity.ChangelogActivities) error
+		mockSetup  func(*repomocks.MockRepository, *repomocks.MockTx)
+		assertBody func(*testing.T, domain.CommitInfo)
+	}{
+		{
+			name: "enriched commit and submodule",
+			run: func(ctx context.Context, acts *activity.ChangelogActivities) error {
+				return acts.StoreEnrichedCommit(ctx, activity.StoreEnrichedCommitInput{
+					VersionID: 10,
+					CommitInfo: domain.CommitInfo{
+						Sha:        "main-sha",
+						Repository: "https://github.com/SpongePowered/Sponge",
+						Author: &domain.CommitAuthor{
+							Name:  "Main Author",
+							Email: "123+main-user@users.noreply.github.com",
+						},
+						Submodules: []domain.SubmoduleCommit{{
+							Repository: "https://github.com/SpongePowered/SpongeAPI",
+							Sha:        "sub-sha",
+							Author: &domain.CommitAuthor{
+								Name:  "Sub Author",
+								Email: "sub-user@users.noreply.github.com",
+							},
+						}},
+					},
+				})
+			},
+			mockSetup: func(repo *repomocks.MockRepository, tx *repomocks.MockTx) {
+				expectCommitBodyUpdate(repo, tx)
+			},
+			assertBody: func(t *testing.T, info domain.CommitInfo) {
+				t.Helper()
+				if got := info.Author.GitHubUsername; got != "main-user" {
+					t.Errorf("main GitHub username = %q, want main-user", got)
+				}
+				if got := info.Submodules[0].Author.GitHubUsername; got != "sub-user" {
+					t.Errorf("submodule GitHub username = %q, want sub-user", got)
+				}
+			},
+		},
+		{
+			name: "main and nested changelogs",
+			run: func(ctx context.Context, acts *activity.ChangelogActivities) error {
+				return acts.StoreChangelog(ctx, activity.StoreChangelogInput{
+					VersionID: 11,
+					Changelog: domain.Changelog{
+						Commits: []domain.CommitSummary{{
+							Sha: "main-sha",
+							URL: "https://github.com/SpongePowered/Sponge/commit/main-sha",
+							Author: &domain.CommitAuthor{
+								Name:  "Main Author",
+								Email: "main-user@users.noreply.github.com",
+							},
+						}},
+						SubmoduleChangelogs: map[string]*domain.Changelog{
+							"https://github.com/SpongePowered/SpongeAPI": {
+								Commits: []domain.CommitSummary{{
+									Sha: "sub-sha",
+									Author: &domain.CommitAuthor{
+										Name:  "Sub Author",
+										Email: "123+sub-user@users.noreply.github.com",
+									},
+								}},
+							},
+						},
+					},
+				})
+			},
+			mockSetup: func(repo *repomocks.MockRepository, tx *repomocks.MockTx) {
+				tx.EXPECT().GetArtifactVersionByID(mock.Anything, int64(11)).
+					Return(db.ArtifactVersion{ID: 11, CommitBody: []byte(`{"sha":"head"}`)}, nil)
+				expectCommitBodyUpdate(repo, tx)
+			},
+			assertBody: func(t *testing.T, info domain.CommitInfo) {
+				t.Helper()
+				if got := info.Changelog.Commits[0].Author.GitHubUsername; got != "main-user" {
+					t.Errorf("changelog GitHub username = %q, want main-user", got)
+				}
+				nested := info.Changelog.SubmoduleChangelogs["https://github.com/SpongePowered/SpongeAPI"]
+				if got := nested.Commits[0].Author.GitHubUsername; got != "sub-user" {
+					t.Errorf("nested GitHub username = %q, want sub-user", got)
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			repo := repomocks.NewMockRepository(t)
+			tx := repomocks.NewMockTx(t)
+			var stored domain.CommitInfo
+
+			tt.mockSetup(repo, tx)
+			tx.EXPECT().UpdateArtifactVersionCommitBody(mock.Anything, mock.MatchedBy(func(params db.UpdateArtifactVersionCommitBodyParams) bool {
+				return json.Unmarshal(params.CommitBody, &stored) == nil
+			})).Return(nil)
+
+			acts := &activity.ChangelogActivities{
+				Repo:   repo,
+				GitHub: githubapi.NewClient(nil, ""),
+			}
+			if err := tt.run(t.Context(), acts); err != nil {
+				t.Fatalf("store commit data: %v", err)
+			}
+			tt.assertBody(t, stored)
+		})
+	}
+}
+
+func expectCommitBodyUpdate(repo *repomocks.MockRepository, tx *repomocks.MockTx) {
+	repo.EXPECT().WithTx(mock.Anything, mock.Anything).RunAndReturn(
+		func(ctx context.Context, fn func(repository.Tx) error) error {
+			return fn(tx)
+		},
+	)
+}
+
+func TestStoreEnrichedCommitReservesPersistenceTime(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		<-r.Context().Done()
+	}))
+	defer server.Close()
+
+	repo := repomocks.NewMockRepository(t)
+	tx := repomocks.NewMockTx(t)
+	var stored domain.CommitInfo
+
+	repo.EXPECT().WithTx(mock.Anything, mock.Anything).RunAndReturn(
+		func(ctx context.Context, fn func(repository.Tx) error) error {
+			if err := ctx.Err(); err != nil {
+				t.Errorf("persistence context already canceled: %v", err)
+			}
+			return fn(tx)
+		},
+	)
+	tx.EXPECT().UpdateArtifactVersionCommitBody(mock.Anything, mock.MatchedBy(func(params db.UpdateArtifactVersionCommitBodyParams) bool {
+		return json.Unmarshal(params.CommitBody, &stored) == nil
+	})).Return(nil)
+
+	acts := &activity.ChangelogActivities{
+		Repo:   repo,
+		GitHub: githubapi.NewClientWithBaseURL(server.Client(), "", server.URL),
+	}
+	ctx, cancel := context.WithTimeout(t.Context(), 5500*time.Millisecond)
+	defer cancel()
+
+	err := acts.StoreEnrichedCommit(ctx, activity.StoreEnrichedCommitInput{
+		VersionID: 10,
+		CommitInfo: domain.CommitInfo{
+			Sha:        "abc123",
+			Repository: "https://github.com/SpongePowered/Sponge",
+			Author: &domain.CommitAuthor{
+				Name:  "Git Author",
+				Email: "author@example.com",
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("StoreEnrichedCommit() error = %v", err)
+	}
+	if stored.Author.GitHubUsername != "" {
+		t.Errorf("GitHubUsername = %q, want fallback without username", stored.Author.GitHubUsername)
 	}
 }

--- a/internal/activity/changelog_activities_test.go
+++ b/internal/activity/changelog_activities_test.go
@@ -3,10 +3,7 @@ package activity_test
 import (
 	"context"
 	"encoding/json"
-	"net/http"
-	"net/http/httptest"
 	"testing"
-	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/jackc/pgx/v5"
@@ -15,7 +12,6 @@ import (
 	"github.com/spongepowered/systemofadownload/internal/activity"
 	"github.com/spongepowered/systemofadownload/internal/db"
 	"github.com/spongepowered/systemofadownload/internal/domain"
-	"github.com/spongepowered/systemofadownload/internal/githubapi"
 	"github.com/spongepowered/systemofadownload/internal/repository"
 	repomocks "github.com/spongepowered/systemofadownload/internal/repository/mocks"
 )
@@ -209,175 +205,37 @@ func TestCheckPreviousVersionEnriched(t *testing.T) {
 	}
 }
 
-func TestStoreCommitDataResolvesGitHubUsernames(t *testing.T) {
+func TestStoreChangelogLocksVersionBeforeMerge(t *testing.T) {
 	t.Parallel()
-
-	tests := []struct {
-		name       string
-		run        func(context.Context, *activity.ChangelogActivities) error
-		mockSetup  func(*repomocks.MockRepository, *repomocks.MockTx)
-		assertBody func(*testing.T, domain.CommitInfo)
-	}{
-		{
-			name: "enriched commit and submodule",
-			run: func(ctx context.Context, acts *activity.ChangelogActivities) error {
-				return acts.StoreEnrichedCommit(ctx, activity.StoreEnrichedCommitInput{
-					VersionID: 10,
-					CommitInfo: domain.CommitInfo{
-						Sha:        "main-sha",
-						Repository: "https://github.com/SpongePowered/Sponge",
-						Author: &domain.CommitAuthor{
-							Name:  "Main Author",
-							Email: "123+main-user@users.noreply.github.com",
-						},
-						Submodules: []domain.SubmoduleCommit{{
-							Repository: "https://github.com/SpongePowered/SpongeAPI",
-							Sha:        "sub-sha",
-							Author: &domain.CommitAuthor{
-								Name:  "Sub Author",
-								Email: "sub-user@users.noreply.github.com",
-							},
-						}},
-					},
-				})
-			},
-			mockSetup: func(repo *repomocks.MockRepository, tx *repomocks.MockTx) {
-				expectCommitBodyUpdate(repo, tx)
-			},
-			assertBody: func(t *testing.T, info domain.CommitInfo) {
-				t.Helper()
-				if got := info.Author.GitHubUsername; got != "main-user" {
-					t.Errorf("main GitHub username = %q, want main-user", got)
-				}
-				if got := info.Submodules[0].Author.GitHubUsername; got != "sub-user" {
-					t.Errorf("submodule GitHub username = %q, want sub-user", got)
-				}
-			},
-		},
-		{
-			name: "main and nested changelogs",
-			run: func(ctx context.Context, acts *activity.ChangelogActivities) error {
-				return acts.StoreChangelog(ctx, activity.StoreChangelogInput{
-					VersionID: 11,
-					Changelog: domain.Changelog{
-						Commits: []domain.CommitSummary{{
-							Sha: "main-sha",
-							URL: "https://github.com/SpongePowered/Sponge/commit/main-sha",
-							Author: &domain.CommitAuthor{
-								Name:  "Main Author",
-								Email: "main-user@users.noreply.github.com",
-							},
-						}},
-						SubmoduleChangelogs: map[string]*domain.Changelog{
-							"https://github.com/SpongePowered/SpongeAPI": {
-								Commits: []domain.CommitSummary{{
-									Sha: "sub-sha",
-									Author: &domain.CommitAuthor{
-										Name:  "Sub Author",
-										Email: "123+sub-user@users.noreply.github.com",
-									},
-								}},
-							},
-						},
-					},
-				})
-			},
-			mockSetup: func(repo *repomocks.MockRepository, tx *repomocks.MockTx) {
-				tx.EXPECT().GetArtifactVersionByID(mock.Anything, int64(11)).
-					Return(db.ArtifactVersion{ID: 11, CommitBody: []byte(`{"sha":"head"}`)}, nil)
-				expectCommitBodyUpdate(repo, tx)
-			},
-			assertBody: func(t *testing.T, info domain.CommitInfo) {
-				t.Helper()
-				if got := info.Changelog.Commits[0].Author.GitHubUsername; got != "main-user" {
-					t.Errorf("changelog GitHub username = %q, want main-user", got)
-				}
-				nested := info.Changelog.SubmoduleChangelogs["https://github.com/SpongePowered/SpongeAPI"]
-				if got := nested.Commits[0].Author.GitHubUsername; got != "sub-user" {
-					t.Errorf("nested GitHub username = %q, want sub-user", got)
-				}
-			},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-			repo := repomocks.NewMockRepository(t)
-			tx := repomocks.NewMockTx(t)
-			var stored domain.CommitInfo
-
-			tt.mockSetup(repo, tx)
-			tx.EXPECT().UpdateArtifactVersionCommitBody(mock.Anything, mock.MatchedBy(func(params db.UpdateArtifactVersionCommitBodyParams) bool {
-				return json.Unmarshal(params.CommitBody, &stored) == nil
-			})).Return(nil)
-
-			acts := &activity.ChangelogActivities{
-				Repo:   repo,
-				GitHub: githubapi.NewClient(nil, ""),
-			}
-			if err := tt.run(t.Context(), acts); err != nil {
-				t.Fatalf("store commit data: %v", err)
-			}
-			tt.assertBody(t, stored)
-		})
-	}
-}
-
-func expectCommitBodyUpdate(repo *repomocks.MockRepository, tx *repomocks.MockTx) {
-	repo.EXPECT().WithTx(mock.Anything, mock.Anything).RunAndReturn(
-		func(ctx context.Context, fn func(repository.Tx) error) error {
-			return fn(tx)
-		},
-	)
-}
-
-func TestStoreEnrichedCommitReservesPersistenceTime(t *testing.T) {
-	t.Parallel()
-
-	server := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
-		<-r.Context().Done()
-	}))
-	defer server.Close()
 
 	repo := repomocks.NewMockRepository(t)
 	tx := repomocks.NewMockTx(t)
-	var stored domain.CommitInfo
-
 	repo.EXPECT().WithTx(mock.Anything, mock.Anything).RunAndReturn(
 		func(ctx context.Context, fn func(repository.Tx) error) error {
-			if err := ctx.Err(); err != nil {
-				t.Errorf("persistence context already canceled: %v", err)
-			}
 			return fn(tx)
 		},
 	)
-	tx.EXPECT().UpdateArtifactVersionCommitBody(mock.Anything, mock.MatchedBy(func(params db.UpdateArtifactVersionCommitBodyParams) bool {
-		return json.Unmarshal(params.CommitBody, &stored) == nil
-	})).Return(nil)
+	tx.EXPECT().GetArtifactVersionForUpdate(mock.Anything, int64(10)).
+		Return(db.ArtifactVersion{
+			ID:         10,
+			CommitBody: []byte(`{"sha":"abc","enrichedAt":"2026-07-27T00:00:00Z","githubAuthorsResolvedAt":"2026-07-27T01:00:00Z"}`),
+		}, nil)
+	tx.EXPECT().UpdateArtifactVersionCommitBody(mock.Anything, mock.MatchedBy(
+		func(params db.UpdateArtifactVersionCommitBodyParams) bool {
+			var info domain.CommitInfo
+			return json.Unmarshal(params.CommitBody, &info) == nil &&
+				info.GitHubAuthorsResolvedAt == ""
+		},
+	)).Return(nil)
 
-	acts := &activity.ChangelogActivities{
-		Repo:   repo,
-		GitHub: githubapi.NewClientWithBaseURL(server.Client(), "", server.URL),
-	}
-	ctx, cancel := context.WithTimeout(t.Context(), 5500*time.Millisecond)
-	defer cancel()
-
-	err := acts.StoreEnrichedCommit(ctx, activity.StoreEnrichedCommitInput{
+	activities := &activity.ChangelogActivities{Repo: repo}
+	err := activities.StoreChangelog(t.Context(), activity.StoreChangelogInput{
 		VersionID: 10,
-		CommitInfo: domain.CommitInfo{
-			Sha:        "abc123",
-			Repository: "https://github.com/SpongePowered/Sponge",
-			Author: &domain.CommitAuthor{
-				Name:  "Git Author",
-				Email: "author@example.com",
-			},
+		Changelog: domain.Changelog{
+			PreviousVersion: "def",
 		},
 	})
 	if err != nil {
-		t.Fatalf("StoreEnrichedCommit() error = %v", err)
-	}
-	if stored.Author.GitHubUsername != "" {
-		t.Errorf("GitHubUsername = %q, want fallback without username", stored.Author.GitHubUsername)
+		t.Fatalf("StoreChangelog() error = %v", err)
 	}
 }

--- a/internal/activity/github_author_resolution.go
+++ b/internal/activity/github_author_resolution.go
@@ -25,6 +25,10 @@ const (
 	githubNegativeCacheTTL = 6 * time.Hour
 )
 
+// errUnresolvableVersion marks a version whose stored state cannot be resolved.
+// Retrying will not help, so the batch skips it without stamping the marker.
+var errUnresolvableVersion = errors.New("version cannot be resolved")
+
 type gitHubAuthorResolver interface {
 	ResolveUsername(ctx context.Context, repoURL, sha, email string) (string, error)
 }
@@ -97,28 +101,15 @@ func (a *GitHubAuthorResolutionActivities) ResolveGitHubAuthorsBatch(
 		versionID := input.VersionIDs[i]
 		resolutions, err := a.resolveVersionAuthors(ctx, versionID, i)
 		if err != nil {
-			if temporalactivity.GetInfo(ctx).Attempt < 3 {
-				var rateLimitErr *githubapi.RateLimitError
-				if errors.As(err, &rateLimitErr) {
-					delay := time.Until(rateLimitErr.ResetAt)
-					if delay < time.Second {
-						delay = time.Second
-					}
-					return temporal.NewApplicationErrorWithOptions(
-						err.Error(),
-						"GithubRateLimit",
-						temporal.ApplicationErrorOptions{NextRetryDelay: delay},
-					)
-				}
-				return temporal.NewApplicationError(err.Error(), "GithubAuthorResolution")
+			if errors.Is(err, errUnresolvableVersion) {
+				slog.WarnContext(ctx, "skipping GitHub author resolution for version",
+					"versionID", versionID,
+					"error", err,
+				)
+				temporalactivity.RecordHeartbeat(ctx, githubResolutionHeartbeat{NextIndex: i + 1})
+				continue
 			}
-
-			slog.WarnContext(ctx, "skipping GitHub author resolution after retries",
-				"versionID", versionID,
-				"error", err,
-			)
-			temporalactivity.RecordHeartbeat(ctx, githubResolutionHeartbeat{NextIndex: i + 1})
-			continue
+			return resolutionFailure(fmt.Errorf("resolving GitHub authors for version %d: %w", versionID, err))
 		}
 
 		if err := a.mergeVersionAuthors(ctx, versionID, resolutions); err != nil {
@@ -128,6 +119,22 @@ func (a *GitHubAuthorResolutionActivities) ResolveGitHubAuthorsBatch(
 	}
 
 	return nil
+}
+
+// resolutionFailure lets GitHub rate limits dictate their own retry delay while
+// leaving every other failure on the activity's default retry backoff.
+func resolutionFailure(err error) error {
+	var rateLimitErr *githubapi.RateLimitError
+	if !errors.As(err, &rateLimitErr) {
+		return err
+	}
+
+	delay := max(time.Until(rateLimitErr.ResetAt), time.Second)
+	return temporal.NewApplicationErrorWithOptions(
+		err.Error(),
+		"GithubRateLimit",
+		temporal.ApplicationErrorOptions{NextRetryDelay: delay},
+	)
 }
 
 type githubAuthorReference struct {
@@ -143,12 +150,15 @@ func (a *GitHubAuthorResolutionActivities) resolveVersionAuthors(
 ) (map[string]string, error) {
 	version, err := a.Repo.GetArtifactVersionByID(ctx, versionID)
 	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, fmt.Errorf("%w: no longer exists", errUnresolvableVersion)
+		}
 		return nil, fmt.Errorf("reading version: %w", err)
 	}
 
 	var info domain.CommitInfo
 	if err := json.Unmarshal(version.CommitBody, &info); err != nil {
-		return nil, fmt.Errorf("unmarshaling commit body: %w", err)
+		return nil, fmt.Errorf("%w: unmarshaling commit body: %w", errUnresolvableVersion, err)
 	}
 	if info.GitHubAuthorsResolvedAt != "" {
 		return map[string]string{}, nil

--- a/internal/activity/github_author_resolution.go
+++ b/internal/activity/github_author_resolution.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"slices"
 	"strings"
 	"time"
 
@@ -20,10 +21,9 @@ import (
 	"github.com/spongepowered/systemofadownload/internal/repository"
 )
 
-const (
-	githubPositiveCacheTTL = 30 * 24 * time.Hour
-	githubNegativeCacheTTL = 6 * time.Hour
-)
+// githubUserCacheTTL applies to hits and misses alike; a commit that GitHub has
+// no account for is a stable answer worth remembering for as long as a hit.
+const githubUserCacheTTL = 30 * 24 * time.Hour
 
 // errUnresolvableVersion marks a version whose stored state cannot be resolved.
 // Retrying will not help, so the batch skips it without stamping the marker.
@@ -39,23 +39,19 @@ type GitHubAuthorResolutionActivities struct {
 	GitHub gitHubAuthorResolver
 }
 
-// FetchGitHubAuthorResolutionPageInput selects one newest-first keyset page.
-type FetchGitHubAuthorResolutionPageInput struct {
+// FetchVersionsNeedingAuthorResolutionInput selects one newest-first keyset page.
+type FetchVersionsNeedingAuthorResolutionInput struct {
 	BeforeID *int64
 	PageSize int32
 }
 
-// FetchGitHubAuthorResolutionPageOutput contains version IDs and the next cursor.
-type FetchGitHubAuthorResolutionPageOutput struct {
-	VersionIDs   []int64
-	NextBeforeID *int64
-}
-
-// FetchGitHubAuthorResolutionPage discovers enriched versions that still need resolution.
-func (a *GitHubAuthorResolutionActivities) FetchGitHubAuthorResolutionPage(
+// FetchVersionsNeedingAuthorResolution returns enriched versions whose author
+// resolution marker is missing or stale, newest first. Only IDs cross the
+// activity boundary; commit bodies never enter workflow history.
+func (a *GitHubAuthorResolutionActivities) FetchVersionsNeedingAuthorResolution(
 	ctx context.Context,
-	input FetchGitHubAuthorResolutionPageInput,
-) (*FetchGitHubAuthorResolutionPageOutput, error) {
+	input FetchVersionsNeedingAuthorResolutionInput,
+) ([]int64, error) {
 	ids, err := a.Repo.ListVersionsNeedingGitHubAuthorResolution(
 		ctx,
 		db.ListVersionsNeedingGitHubAuthorResolutionParams{
@@ -66,13 +62,7 @@ func (a *GitHubAuthorResolutionActivities) FetchGitHubAuthorResolutionPage(
 	if err != nil {
 		return nil, fmt.Errorf("listing versions needing GitHub author resolution: %w", err)
 	}
-
-	output := &FetchGitHubAuthorResolutionPageOutput{VersionIDs: ids}
-	if len(ids) > 0 {
-		next := ids[len(ids)-1]
-		output.NextBeforeID = &next
-	}
-	return output, nil
+	return ids, nil
 }
 
 // ResolveGitHubAuthorsBatchInput is one page of artifact version IDs.
@@ -80,45 +70,192 @@ type ResolveGitHubAuthorsBatchInput struct {
 	VersionIDs []int64
 }
 
+// ResolveGitHubAuthorsBatchOutput reports counts only, never commit payloads.
+type ResolveGitHubAuthorsBatchOutput struct {
+	VersionsStamped   int
+	AuthorsResolved   int
+	AuthorsUnresolved int
+}
+
 type githubResolutionHeartbeat struct {
 	NextIndex int
 }
 
-// ResolveGitHubAuthorsBatch resolves and persists authors for one page.
+// pendingVersion is a version awaiting the merge phase.
+type pendingVersion struct {
+	Index      int
+	VersionID  int64
+	References []githubAuthorReference
+}
+
+// ResolveGitHubAuthorsBatch resolves and persists authors for one page. GitHub
+// lookups are deduplicated across the whole page and served from a shared cache
+// first, so a page usually costs no API calls at all.
 func (a *GitHubAuthorResolutionActivities) ResolveGitHubAuthorsBatch(
 	ctx context.Context,
 	input ResolveGitHubAuthorsBatchInput,
-) error {
+) (*ResolveGitHubAuthorsBatchOutput, error) {
 	start := 0
 	var heartbeat githubResolutionHeartbeat
 	if temporalactivity.HasHeartbeatDetails(ctx) {
 		if err := temporalactivity.GetHeartbeatDetails(ctx, &heartbeat); err == nil {
-			start = heartbeat.NextIndex
+			start = min(max(heartbeat.NextIndex, 0), len(input.VersionIDs))
 		}
 	}
 
-	for i := start; i < len(input.VersionIDs); i++ {
-		versionID := input.VersionIDs[i]
-		resolutions, err := a.resolveVersionAuthors(ctx, versionID, i)
+	pending, references, err := a.collectPageAuthors(ctx, input.VersionIDs, start)
+	if err != nil {
+		return nil, err
+	}
+
+	resolutions, err := a.resolvePageAuthors(ctx, references, start)
+	if err != nil {
+		return nil, err
+	}
+
+	output := &ResolveGitHubAuthorsBatchOutput{}
+	for _, version := range pending {
+		merged, err := a.mergeVersionAuthors(ctx, version.VersionID, resolutions)
+		if err != nil {
+			return nil, fmt.Errorf("merging GitHub authors for version %d: %w", version.VersionID, err)
+		}
+		if merged.Stamped {
+			output.VersionsStamped++
+			output.AuthorsResolved += merged.Resolved
+			output.AuthorsUnresolved += merged.Unresolved
+		}
+		temporalactivity.RecordHeartbeat(ctx, githubResolutionHeartbeat{NextIndex: version.Index + 1})
+	}
+	return output, nil
+}
+
+// collectPageAuthors reads every version in the page without locking and
+// deduplicates their authors, so the GitHub phase never holds a row lock.
+func (a *GitHubAuthorResolutionActivities) collectPageAuthors(
+	ctx context.Context,
+	versionIDs []int64,
+	start int,
+) ([]pendingVersion, map[string]githubAuthorReference, error) {
+	var pending []pendingVersion
+	references := make(map[string]githubAuthorReference)
+
+	for i := start; i < len(versionIDs); i++ {
+		versionID := versionIDs[i]
+		info, err := a.loadCommitInfo(ctx, versionID)
 		if err != nil {
 			if errors.Is(err, errUnresolvableVersion) {
 				slog.WarnContext(ctx, "skipping GitHub author resolution for version",
 					"versionID", versionID,
 					"error", err,
 				)
-				temporalactivity.RecordHeartbeat(ctx, githubResolutionHeartbeat{NextIndex: i + 1})
 				continue
 			}
-			return resolutionFailure(fmt.Errorf("resolving GitHub authors for version %d: %w", versionID, err))
+			return nil, nil, fmt.Errorf("reading version %d: %w", versionID, err)
+		}
+		if info == nil {
+			continue
 		}
 
-		if err := a.mergeVersionAuthors(ctx, versionID, resolutions); err != nil {
-			return fmt.Errorf("merging GitHub authors for version %d: %w", versionID, err)
+		versionReferences := collectGithubAuthorReferences(info)
+		pending = append(pending, pendingVersion{
+			Index:      i,
+			VersionID:  versionID,
+			References: versionReferences,
+		})
+		for _, ref := range versionReferences {
+			references[githubAuthorKey(ref)] = ref
 		}
-		temporalactivity.RecordHeartbeat(ctx, githubResolutionHeartbeat{NextIndex: i + 1})
+	}
+	return pending, references, nil
+}
+
+// resolvePageAuthors serves the page's authors from the shared cache in one
+// query and only calls GitHub for what is left.
+func (a *GitHubAuthorResolutionActivities) resolvePageAuthors(
+	ctx context.Context,
+	references map[string]githubAuthorReference,
+	nextIndex int,
+) (map[string]string, error) {
+	resolutions, err := a.lookupCachedUsernames(ctx, references)
+	if err != nil {
+		return nil, err
 	}
 
-	return nil
+	keys := make([]string, 0, len(references))
+	for key := range references {
+		if _, cached := resolutions[key]; !cached {
+			keys = append(keys, key)
+		}
+	}
+	slices.Sort(keys)
+
+	for _, key := range keys {
+		username, err := a.resolveUncachedAuthor(ctx, references[key])
+		if err != nil {
+			return nil, resolutionFailure(err)
+		}
+		resolutions[key] = username
+		temporalactivity.RecordHeartbeat(ctx, githubResolutionHeartbeat{NextIndex: nextIndex})
+	}
+	return resolutions, nil
+}
+
+func (a *GitHubAuthorResolutionActivities) lookupCachedUsernames(
+	ctx context.Context,
+	references map[string]githubAuthorReference,
+) (map[string]string, error) {
+	emails := make([]string, 0, len(references))
+	for key, ref := range references {
+		email, ok := strings.CutPrefix(key, githubAuthorEmailKeyPrefix)
+		if !ok {
+			continue
+		}
+		// Noreply addresses carry the username, so they never reach the cache.
+		if githubapi.UsernameFromNoreplyEmail(normalizeAuthorEmail(ref.Author.Email)) != "" {
+			continue
+		}
+		emails = append(emails, email)
+	}
+	resolutions := make(map[string]string, len(references))
+	if len(emails) == 0 {
+		return resolutions, nil
+	}
+	slices.Sort(emails)
+
+	cached, err := a.Repo.GetGitHubUserCacheBatch(ctx, emails)
+	if err != nil {
+		return nil, fmt.Errorf("reading GitHub user cache: %w", err)
+	}
+	for _, entry := range cached {
+		username := ""
+		if entry.GithubUsername != nil {
+			username = *entry.GithubUsername
+		}
+		resolutions[githubAuthorEmailKeyPrefix+entry.AuthorEmail] = username
+	}
+	return resolutions, nil
+}
+
+func (a *GitHubAuthorResolutionActivities) resolveUncachedAuthor(
+	ctx context.Context,
+	ref githubAuthorReference,
+) (string, error) {
+	email := normalizeAuthorEmail(ref.Author.Email)
+	if username := githubapi.UsernameFromNoreplyEmail(email); username != "" {
+		return username, nil
+	}
+
+	username, err := a.GitHub.ResolveUsername(ctx, ref.Repository, ref.Sha, email)
+	if err != nil {
+		return "", fmt.Errorf("resolving GitHub author: %w", err)
+	}
+	if email == "" {
+		return username, nil
+	}
+	if err := a.storeGithubUserCache(ctx, email, username); err != nil {
+		return "", err
+	}
+	return username, nil
 }
 
 // resolutionFailure lets GitHub rate limits dictate their own retry delay while
@@ -137,93 +274,38 @@ func resolutionFailure(err error) error {
 	)
 }
 
-type githubAuthorReference struct {
-	Author     *domain.CommitAuthor
-	Repository string
-	Sha        string
-}
-
-func (a *GitHubAuthorResolutionActivities) resolveVersionAuthors(
+// loadCommitInfo returns nil when the version is already resolved at the
+// current schema and nothing needs doing.
+func (a *GitHubAuthorResolutionActivities) loadCommitInfo(
 	ctx context.Context,
 	versionID int64,
-	versionIndex int,
-) (map[string]string, error) {
+) (*domain.CommitInfo, error) {
 	version, err := a.Repo.GetArtifactVersionByID(ctx, versionID)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, fmt.Errorf("%w: no longer exists", errUnresolvableVersion)
 		}
-		return nil, fmt.Errorf("reading version: %w", err)
+		return nil, err
 	}
 
 	var info domain.CommitInfo
 	if err := json.Unmarshal(version.CommitBody, &info); err != nil {
 		return nil, fmt.Errorf("%w: unmarshaling commit body: %w", errUnresolvableVersion, err)
 	}
-	if info.GitHubAuthorsResolvedAt != "" {
-		return map[string]string{}, nil
+	if authorResolutionCurrent(&info) {
+		return nil, nil
 	}
-
-	references := collectGithubAuthorReferences(&info)
-	resolutions := make(map[string]string, len(references))
-	for _, ref := range references {
-		key := githubAuthorKey(ref)
-		if _, ok := resolutions[key]; ok {
-			continue
-		}
-
-		username, err := a.resolveGithubAuthor(ctx, ref)
-		if err != nil {
-			return nil, err
-		}
-		resolutions[key] = username
-		temporalactivity.RecordHeartbeat(ctx, githubResolutionHeartbeat{NextIndex: versionIndex})
-	}
-	return resolutions, nil
+	return &info, nil
 }
 
-func (a *GitHubAuthorResolutionActivities) resolveGithubAuthor(
-	ctx context.Context,
-	ref githubAuthorReference,
-) (string, error) {
-	email := normalizeAuthorEmail(ref.Author.Email)
-	if username := githubapi.UsernameFromNoreplyEmail(email); username != "" {
-		return username, nil
-	}
-
-	if email != "" {
-		cached, err := a.Repo.GetGitHubUserCache(ctx, email)
-		if err == nil {
-			if cached.GithubUsername == nil {
-				return "", nil
-			}
-			return *cached.GithubUsername, nil
-		}
-		if !errors.Is(err, pgx.ErrNoRows) {
-			return "", fmt.Errorf("reading GitHub user cache: %w", err)
-		}
-	}
-
-	username, err := a.GitHub.ResolveUsername(ctx, ref.Repository, ref.Sha, email)
-	if err != nil {
-		return "", fmt.Errorf("resolving GitHub author: %w", err)
-	}
-	if email != "" {
-		ttl := githubPositiveCacheTTL
-		if username == "" {
-			ttl = githubNegativeCacheTTL
-		}
-		if err := a.storeGithubUserCache(ctx, email, username, ttl); err != nil {
-			return "", err
-		}
-	}
-	return username, nil
+func authorResolutionCurrent(info *domain.CommitInfo) bool {
+	return info.AuthorResolution != nil &&
+		info.AuthorResolution.Schema >= domain.AuthorResolutionSchema
 }
 
 func (a *GitHubAuthorResolutionActivities) storeGithubUserCache(
 	ctx context.Context,
 	email, username string,
-	ttl time.Duration,
 ) error {
 	return a.Repo.WithTx(ctx, func(tx repository.Tx) error {
 		var usernamePtr *string
@@ -234,7 +316,7 @@ func (a *GitHubAuthorResolutionActivities) storeGithubUserCache(
 			AuthorEmail:    email,
 			GithubUsername: usernamePtr,
 			ExpiresAt: pgtype.Timestamptz{
-				Time:  time.Now().Add(ttl),
+				Time:  time.Now().Add(githubUserCacheTTL),
 				Valid: true,
 			},
 		})
@@ -242,12 +324,22 @@ func (a *GitHubAuthorResolutionActivities) storeGithubUserCache(
 	})
 }
 
+// versionMergeResult reports what a single locked merge did.
+type versionMergeResult struct {
+	Stamped    bool
+	Resolved   int
+	Unresolved int
+}
+
 func (a *GitHubAuthorResolutionActivities) mergeVersionAuthors(
 	ctx context.Context,
 	versionID int64,
 	resolutions map[string]string,
-) error {
-	return a.Repo.WithTx(ctx, func(tx repository.Tx) error {
+) (versionMergeResult, error) {
+	var result versionMergeResult
+	err := a.Repo.WithTx(ctx, func(tx repository.Tx) error {
+		result = versionMergeResult{}
+
 		version, err := tx.GetArtifactVersionForUpdate(ctx, versionID)
 		if err != nil {
 			return err
@@ -257,20 +349,30 @@ func (a *GitHubAuthorResolutionActivities) mergeVersionAuthors(
 		if err := json.Unmarshal(version.CommitBody, &info); err != nil {
 			return fmt.Errorf("unmarshaling locked commit body: %w", err)
 		}
-		if info.GitHubAuthorsResolvedAt != "" {
+		if authorResolutionCurrent(&info) {
 			return nil
 		}
 
-		references := collectGithubAuthorReferences(&info)
-		for _, ref := range references {
+		for _, ref := range collectGithubAuthorReferences(&info) {
 			username, ok := resolutions[githubAuthorKey(ref)]
 			if !ok {
+				// The body changed while we were resolving; leave the marker
+				// off so the next tick picks this version up again.
 				return nil
 			}
 			ref.Author.GitHubUsername = username
+			if username == "" {
+				result.Unresolved++
+			} else {
+				result.Resolved++
+			}
 		}
 
-		info.GitHubAuthorsResolvedAt = time.Now().UTC().Format(time.RFC3339)
+		info.AuthorResolution = &domain.AuthorResolution{
+			At:         time.Now().UTC().Format(time.RFC3339),
+			Unresolved: result.Unresolved,
+			Schema:     domain.AuthorResolutionSchema,
+		}
 		data, err := json.Marshal(info)
 		if err != nil {
 			return fmt.Errorf("marshaling resolved commit body: %w", err)
@@ -281,8 +383,19 @@ func (a *GitHubAuthorResolutionActivities) mergeVersionAuthors(
 		}); err != nil {
 			return err
 		}
+		result.Stamped = true
 		return nil
 	})
+	if err != nil {
+		return versionMergeResult{}, err
+	}
+	return result, nil
+}
+
+type githubAuthorReference struct {
+	Author     *domain.CommitAuthor
+	Repository string
+	Sha        string
 }
 
 func collectGithubAuthorReferences(info *domain.CommitInfo) []githubAuthorReference {
@@ -332,9 +445,14 @@ func appendGithubAuthorReference(
 	})
 }
 
+const githubAuthorEmailKeyPrefix = "email:"
+
+// githubAuthorKey dedupes authors across the page. Email is the shared cache
+// key; authors without one fall back to their commit, which stays local to
+// this run.
 func githubAuthorKey(ref githubAuthorReference) string {
 	if email := normalizeAuthorEmail(ref.Author.Email); email != "" {
-		return "email:" + email
+		return githubAuthorEmailKeyPrefix + email
 	}
 	return "commit:" + strings.ToLower(strings.TrimSpace(ref.Repository)) + "@" + strings.TrimSpace(ref.Sha)
 }

--- a/internal/activity/github_author_resolution.go
+++ b/internal/activity/github_author_resolution.go
@@ -1,0 +1,334 @@
+package activity
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"strings"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
+	temporalactivity "go.temporal.io/sdk/activity"
+	"go.temporal.io/sdk/temporal"
+
+	"github.com/spongepowered/systemofadownload/internal/db"
+	"github.com/spongepowered/systemofadownload/internal/domain"
+	"github.com/spongepowered/systemofadownload/internal/githubapi"
+	"github.com/spongepowered/systemofadownload/internal/repository"
+)
+
+const (
+	githubPositiveCacheTTL = 30 * 24 * time.Hour
+	githubNegativeCacheTTL = 6 * time.Hour
+)
+
+type gitHubAuthorResolver interface {
+	ResolveUsername(ctx context.Context, repoURL, sha, email string) (string, error)
+}
+
+// GitHubAuthorResolutionActivities owns durable GitHub author lookup and persistence.
+type GitHubAuthorResolutionActivities struct {
+	Repo   repository.Repository
+	GitHub gitHubAuthorResolver
+}
+
+// FetchGitHubAuthorResolutionPageInput selects one newest-first keyset page.
+type FetchGitHubAuthorResolutionPageInput struct {
+	BeforeID *int64
+	PageSize int32
+}
+
+// FetchGitHubAuthorResolutionPageOutput contains version IDs and the next cursor.
+type FetchGitHubAuthorResolutionPageOutput struct {
+	VersionIDs   []int64
+	NextBeforeID *int64
+}
+
+// FetchGitHubAuthorResolutionPage discovers enriched versions that still need resolution.
+func (a *GitHubAuthorResolutionActivities) FetchGitHubAuthorResolutionPage(
+	ctx context.Context,
+	input FetchGitHubAuthorResolutionPageInput,
+) (*FetchGitHubAuthorResolutionPageOutput, error) {
+	ids, err := a.Repo.ListVersionsNeedingGitHubAuthorResolution(
+		ctx,
+		db.ListVersionsNeedingGitHubAuthorResolutionParams{
+			BeforeID: input.BeforeID,
+			PageSize: input.PageSize,
+		},
+	)
+	if err != nil {
+		return nil, fmt.Errorf("listing versions needing GitHub author resolution: %w", err)
+	}
+
+	output := &FetchGitHubAuthorResolutionPageOutput{VersionIDs: ids}
+	if len(ids) > 0 {
+		next := ids[len(ids)-1]
+		output.NextBeforeID = &next
+	}
+	return output, nil
+}
+
+// ResolveGitHubAuthorsBatchInput is one page of artifact version IDs.
+type ResolveGitHubAuthorsBatchInput struct {
+	VersionIDs []int64
+}
+
+type githubResolutionHeartbeat struct {
+	NextIndex int
+}
+
+// ResolveGitHubAuthorsBatch resolves and persists authors for one page.
+func (a *GitHubAuthorResolutionActivities) ResolveGitHubAuthorsBatch(
+	ctx context.Context,
+	input ResolveGitHubAuthorsBatchInput,
+) error {
+	start := 0
+	var heartbeat githubResolutionHeartbeat
+	if temporalactivity.HasHeartbeatDetails(ctx) {
+		if err := temporalactivity.GetHeartbeatDetails(ctx, &heartbeat); err == nil {
+			start = heartbeat.NextIndex
+		}
+	}
+
+	for i := start; i < len(input.VersionIDs); i++ {
+		versionID := input.VersionIDs[i]
+		resolutions, err := a.resolveVersionAuthors(ctx, versionID, i)
+		if err != nil {
+			if temporalactivity.GetInfo(ctx).Attempt < 3 {
+				var rateLimitErr *githubapi.RateLimitError
+				if errors.As(err, &rateLimitErr) {
+					delay := time.Until(rateLimitErr.ResetAt)
+					if delay < time.Second {
+						delay = time.Second
+					}
+					return temporal.NewApplicationErrorWithOptions(
+						err.Error(),
+						"GithubRateLimit",
+						temporal.ApplicationErrorOptions{NextRetryDelay: delay},
+					)
+				}
+				return temporal.NewApplicationError(err.Error(), "GithubAuthorResolution")
+			}
+
+			slog.WarnContext(ctx, "skipping GitHub author resolution after retries",
+				"versionID", versionID,
+				"error", err,
+			)
+			temporalactivity.RecordHeartbeat(ctx, githubResolutionHeartbeat{NextIndex: i + 1})
+			continue
+		}
+
+		if err := a.mergeVersionAuthors(ctx, versionID, resolutions); err != nil {
+			return fmt.Errorf("merging GitHub authors for version %d: %w", versionID, err)
+		}
+		temporalactivity.RecordHeartbeat(ctx, githubResolutionHeartbeat{NextIndex: i + 1})
+	}
+
+	return nil
+}
+
+type githubAuthorReference struct {
+	Author     *domain.CommitAuthor
+	Repository string
+	Sha        string
+}
+
+func (a *GitHubAuthorResolutionActivities) resolveVersionAuthors(
+	ctx context.Context,
+	versionID int64,
+	versionIndex int,
+) (map[string]string, error) {
+	version, err := a.Repo.GetArtifactVersionByID(ctx, versionID)
+	if err != nil {
+		return nil, fmt.Errorf("reading version: %w", err)
+	}
+
+	var info domain.CommitInfo
+	if err := json.Unmarshal(version.CommitBody, &info); err != nil {
+		return nil, fmt.Errorf("unmarshaling commit body: %w", err)
+	}
+	if info.GitHubAuthorsResolvedAt != "" {
+		return map[string]string{}, nil
+	}
+
+	references := collectGithubAuthorReferences(&info)
+	resolutions := make(map[string]string, len(references))
+	for _, ref := range references {
+		key := githubAuthorKey(ref)
+		if _, ok := resolutions[key]; ok {
+			continue
+		}
+
+		username, err := a.resolveGithubAuthor(ctx, ref)
+		if err != nil {
+			return nil, err
+		}
+		resolutions[key] = username
+		temporalactivity.RecordHeartbeat(ctx, githubResolutionHeartbeat{NextIndex: versionIndex})
+	}
+	return resolutions, nil
+}
+
+func (a *GitHubAuthorResolutionActivities) resolveGithubAuthor(
+	ctx context.Context,
+	ref githubAuthorReference,
+) (string, error) {
+	email := normalizeAuthorEmail(ref.Author.Email)
+	if username := githubapi.UsernameFromNoreplyEmail(email); username != "" {
+		return username, nil
+	}
+
+	if email != "" {
+		cached, err := a.Repo.GetGitHubUserCache(ctx, email)
+		if err == nil {
+			if cached.GithubUsername == nil {
+				return "", nil
+			}
+			return *cached.GithubUsername, nil
+		}
+		if !errors.Is(err, pgx.ErrNoRows) {
+			return "", fmt.Errorf("reading GitHub user cache: %w", err)
+		}
+	}
+
+	username, err := a.GitHub.ResolveUsername(ctx, ref.Repository, ref.Sha, email)
+	if err != nil {
+		return "", fmt.Errorf("resolving GitHub author: %w", err)
+	}
+	if email != "" {
+		ttl := githubPositiveCacheTTL
+		if username == "" {
+			ttl = githubNegativeCacheTTL
+		}
+		if err := a.storeGithubUserCache(ctx, email, username, ttl); err != nil {
+			return "", err
+		}
+	}
+	return username, nil
+}
+
+func (a *GitHubAuthorResolutionActivities) storeGithubUserCache(
+	ctx context.Context,
+	email, username string,
+	ttl time.Duration,
+) error {
+	return a.Repo.WithTx(ctx, func(tx repository.Tx) error {
+		var usernamePtr *string
+		if username != "" {
+			usernamePtr = &username
+		}
+		_, err := tx.UpsertGitHubUserCache(ctx, db.UpsertGitHubUserCacheParams{
+			AuthorEmail:    email,
+			GithubUsername: usernamePtr,
+			ExpiresAt: pgtype.Timestamptz{
+				Time:  time.Now().Add(ttl),
+				Valid: true,
+			},
+		})
+		return err
+	})
+}
+
+func (a *GitHubAuthorResolutionActivities) mergeVersionAuthors(
+	ctx context.Context,
+	versionID int64,
+	resolutions map[string]string,
+) error {
+	return a.Repo.WithTx(ctx, func(tx repository.Tx) error {
+		version, err := tx.GetArtifactVersionForUpdate(ctx, versionID)
+		if err != nil {
+			return err
+		}
+
+		var info domain.CommitInfo
+		if err := json.Unmarshal(version.CommitBody, &info); err != nil {
+			return fmt.Errorf("unmarshaling locked commit body: %w", err)
+		}
+		if info.GitHubAuthorsResolvedAt != "" {
+			return nil
+		}
+
+		references := collectGithubAuthorReferences(&info)
+		for _, ref := range references {
+			username, ok := resolutions[githubAuthorKey(ref)]
+			if !ok {
+				return nil
+			}
+			ref.Author.GitHubUsername = username
+		}
+
+		info.GitHubAuthorsResolvedAt = time.Now().UTC().Format(time.RFC3339)
+		data, err := json.Marshal(info)
+		if err != nil {
+			return fmt.Errorf("marshaling resolved commit body: %w", err)
+		}
+		if err := tx.UpdateArtifactVersionCommitBody(ctx, db.UpdateArtifactVersionCommitBodyParams{
+			ID:         versionID,
+			CommitBody: data,
+		}); err != nil {
+			return err
+		}
+		return nil
+	})
+}
+
+func collectGithubAuthorReferences(info *domain.CommitInfo) []githubAuthorReference {
+	var references []githubAuthorReference
+	appendGithubAuthorReference(&references, info.Author, info.Repository, info.Sha)
+	for i := range info.Submodules {
+		submodule := &info.Submodules[i]
+		appendGithubAuthorReference(&references, submodule.Author, submodule.Repository, submodule.Sha)
+	}
+	collectGithubChangelogReferences(&references, info.Changelog, info.Repository)
+	return references
+}
+
+func collectGithubChangelogReferences(
+	references *[]githubAuthorReference,
+	changelog *domain.Changelog,
+	repositoryURL string,
+) {
+	if changelog == nil {
+		return
+	}
+	for i := range changelog.Commits {
+		commit := &changelog.Commits[i]
+		repoURL := repositoryURL
+		if owner, repo, ok := githubapi.ParseRepository(commit.URL); ok {
+			repoURL = "https://github.com/" + owner + "/" + repo
+		}
+		appendGithubAuthorReference(references, commit.Author, repoURL, commit.Sha)
+	}
+	for submoduleURL, submoduleChangelog := range changelog.SubmoduleChangelogs {
+		collectGithubChangelogReferences(references, submoduleChangelog, submoduleURL)
+	}
+}
+
+func appendGithubAuthorReference(
+	references *[]githubAuthorReference,
+	author *domain.CommitAuthor,
+	repositoryURL, sha string,
+) {
+	if author == nil {
+		return
+	}
+	*references = append(*references, githubAuthorReference{
+		Author:     author,
+		Repository: repositoryURL,
+		Sha:        sha,
+	})
+}
+
+func githubAuthorKey(ref githubAuthorReference) string {
+	if email := normalizeAuthorEmail(ref.Author.Email); email != "" {
+		return "email:" + email
+	}
+	return "commit:" + strings.ToLower(strings.TrimSpace(ref.Repository)) + "@" + strings.TrimSpace(ref.Sha)
+}
+
+func normalizeAuthorEmail(email string) string {
+	return strings.ToLower(strings.TrimSpace(email))
+}

--- a/internal/activity/github_author_resolution_test.go
+++ b/internal/activity/github_author_resolution_test.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/jackc/pgx/v5"
 	"github.com/stretchr/testify/mock"
 
 	"github.com/spongepowered/systemofadownload/internal/activity"
@@ -33,7 +32,7 @@ func (f *fakeGitHubAuthorResolver) ResolveUsername(
 	return f.username, f.err
 }
 
-func TestFetchGitHubAuthorResolutionPage(t *testing.T) {
+func TestFetchVersionsNeedingAuthorResolution(t *testing.T) {
 	t.Parallel()
 
 	repo := repomocks.NewMockRepository(t)
@@ -47,18 +46,18 @@ func TestFetchGitHubAuthorResolutionPage(t *testing.T) {
 	).Return([]int64{90, 80}, nil)
 
 	activities := &activity.GitHubAuthorResolutionActivities{Repo: repo}
-	got, err := activities.FetchGitHubAuthorResolutionPage(
+	got, err := activities.FetchVersionsNeedingAuthorResolution(
 		t.Context(),
-		activity.FetchGitHubAuthorResolutionPageInput{
+		activity.FetchVersionsNeedingAuthorResolutionInput{
 			BeforeID: &beforeID,
 			PageSize: 50,
 		},
 	)
 	if err != nil {
-		t.Fatalf("FetchGitHubAuthorResolutionPage() error = %v", err)
+		t.Fatalf("FetchVersionsNeedingAuthorResolution() error = %v", err)
 	}
-	if len(got.VersionIDs) != 2 || got.NextBeforeID == nil || *got.NextBeforeID != 80 {
-		t.Fatalf("FetchGitHubAuthorResolutionPage() = %#v", got)
+	if len(got) != 2 || got[len(got)-1] != 80 {
+		t.Fatalf("FetchVersionsNeedingAuthorResolution() = %#v", got)
 	}
 }
 
@@ -105,11 +104,11 @@ func TestResolveGitHubAuthorsBatchUsesPersistentCacheAndLocksVersion(t *testing.
 	resolver := &fakeGitHubAuthorResolver{}
 	repo.EXPECT().GetArtifactVersionByID(mock.Anything, int64(10)).
 		Return(db.ArtifactVersion{ID: 10, CommitBody: body}, nil)
-	repo.EXPECT().GetGitHubUserCache(mock.Anything, "cached@example.com").
-		Return(db.GithubUserCache{
+	repo.EXPECT().GetGitHubUserCacheBatch(mock.Anything, []string{"cached@example.com"}).
+		Return([]db.GithubUserCache{{
 			AuthorEmail:    "cached@example.com",
 			GithubUsername: &cachedUsername,
-		}, nil)
+		}}, nil)
 	repo.EXPECT().WithTx(mock.Anything, mock.Anything).RunAndReturn(
 		func(ctx context.Context, fn func(repository.Tx) error) error {
 			return fn(tx)
@@ -127,7 +126,8 @@ func TestResolveGitHubAuthorsBatchUsesPersistentCacheAndLocksVersion(t *testing.
 			return updated.Author.GitHubUsername == "cached-user" &&
 				updated.Changelog.Commits[0].Author.GitHubUsername == "cached-user" &&
 				nested.Commits[0].Author.GitHubUsername == "noreply-user" &&
-				updated.GitHubAuthorsResolvedAt != ""
+				updated.AuthorResolution != nil &&
+				updated.AuthorResolution.Schema == domain.AuthorResolutionSchema
 		},
 	)).Return(nil)
 
@@ -168,8 +168,8 @@ func TestResolveGitHubAuthorsBatchUsesGitHubOnCacheMiss(t *testing.T) {
 	resolver := &fakeGitHubAuthorResolver{username: "octocat"}
 	repo.EXPECT().GetArtifactVersionByID(mock.Anything, int64(10)).
 		Return(db.ArtifactVersion{ID: 10, CommitBody: body}, nil)
-	repo.EXPECT().GetGitHubUserCache(mock.Anything, "author@example.com").
-		Return(db.GithubUserCache{}, pgx.ErrNoRows)
+	repo.EXPECT().GetGitHubUserCacheBatch(mock.Anything, []string{"author@example.com"}).
+		Return(nil, nil)
 	repo.EXPECT().WithTx(mock.Anything, mock.Anything).RunAndReturn(
 		func(ctx context.Context, fn func(repository.Tx) error) error {
 			return fn(tx)
@@ -257,8 +257,8 @@ func TestResolveGitHubAuthorsBatchRetriesTransientFailure(t *testing.T) {
 	resolver := &fakeGitHubAuthorResolver{err: errors.New("github unavailable")}
 	repo.EXPECT().GetArtifactVersionByID(mock.Anything, int64(10)).
 		Return(db.ArtifactVersion{ID: 10, CommitBody: body}, nil)
-	repo.EXPECT().GetGitHubUserCache(mock.Anything, "author@example.com").
-		Return(db.GithubUserCache{}, pgx.ErrNoRows)
+	repo.EXPECT().GetGitHubUserCacheBatch(mock.Anything, []string{"author@example.com"}).
+		Return(nil, nil)
 
 	activities := &activity.GitHubAuthorResolutionActivities{Repo: repo, GitHub: resolver}
 	env := newActivityEnv(t)
@@ -278,17 +278,15 @@ func TestResolveGitHubAuthorsBatchRetriesTransientFailure(t *testing.T) {
 func TestResolveGitHubAuthorsBatchResumesFromHeartbeat(t *testing.T) {
 	t.Parallel()
 
-	info := domain.CommitInfo{
-		EnrichedAt:              "2026-07-27T00:00:00Z",
-		GitHubAuthorsResolvedAt: "2026-07-27T01:00:00Z",
-	}
-	body, err := json.Marshal(info)
+	// No authors, so the version needs no lookups but must still be stamped.
+	body, err := json.Marshal(domain.CommitInfo{EnrichedAt: "2026-07-27T00:00:00Z"})
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	repo := repomocks.NewMockRepository(t)
 	tx := repomocks.NewMockTx(t)
+	// Version 10 precedes the heartbeat index and must never be touched.
 	repo.EXPECT().GetArtifactVersionByID(mock.Anything, int64(20)).
 		Return(db.ArtifactVersion{ID: 20, CommitBody: body}, nil)
 	repo.EXPECT().WithTx(mock.Anything, mock.Anything).RunAndReturn(
@@ -298,6 +296,7 @@ func TestResolveGitHubAuthorsBatchResumesFromHeartbeat(t *testing.T) {
 	)
 	tx.EXPECT().GetArtifactVersionForUpdate(mock.Anything, int64(20)).
 		Return(db.ArtifactVersion{ID: 20, CommitBody: body}, nil)
+	tx.EXPECT().UpdateArtifactVersionCommitBody(mock.Anything, mock.Anything).Return(nil)
 
 	activities := &activity.GitHubAuthorResolutionActivities{Repo: repo}
 	env := newActivityEnv(t)
@@ -310,6 +309,36 @@ func TestResolveGitHubAuthorsBatchResumesFromHeartbeat(t *testing.T) {
 		activity.ResolveGitHubAuthorsBatchInput{VersionIDs: []int64{10, 20}},
 	)
 	if err != nil {
+		t.Fatalf("ResolveGitHubAuthorsBatch() error = %v", err)
+	}
+}
+
+func TestResolveGitHubAuthorsBatchSkipsVersionAlreadyAtCurrentSchema(t *testing.T) {
+	t.Parallel()
+
+	body, err := json.Marshal(domain.CommitInfo{
+		EnrichedAt: "2026-07-27T00:00:00Z",
+		AuthorResolution: &domain.AuthorResolution{
+			At:     "2026-07-27T01:00:00Z",
+			Schema: domain.AuthorResolutionSchema,
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	repo := repomocks.NewMockRepository(t)
+	repo.EXPECT().GetArtifactVersionByID(mock.Anything, int64(20)).
+		Return(db.ArtifactVersion{ID: 20, CommitBody: body}, nil)
+
+	activities := &activity.GitHubAuthorResolutionActivities{Repo: repo}
+	env := newActivityEnv(t)
+	env.RegisterActivity(activities.ResolveGitHubAuthorsBatch)
+	// No WithTx expectation: an up-to-date marker must not be rewritten.
+	if _, err := env.ExecuteActivity(
+		activities.ResolveGitHubAuthorsBatch,
+		activity.ResolveGitHubAuthorsBatchInput{VersionIDs: []int64{20}},
+	); err != nil {
 		t.Fatalf("ResolveGitHubAuthorsBatch() error = %v", err)
 	}
 }

--- a/internal/activity/github_author_resolution_test.go
+++ b/internal/activity/github_author_resolution_test.go
@@ -3,6 +3,8 @@ package activity_test
 import (
 	"context"
 	"encoding/json"
+	"errors"
+	"strings"
 	"testing"
 
 	"github.com/jackc/pgx/v5"
@@ -199,6 +201,77 @@ func TestResolveGitHubAuthorsBatchUsesGitHubOnCacheMiss(t *testing.T) {
 	}
 	if resolver.calls != 1 {
 		t.Errorf("GitHub API calls = %d, want 1", resolver.calls)
+	}
+}
+
+func TestResolveGitHubAuthorsBatchSkipsUnresolvableVersion(t *testing.T) {
+	t.Parallel()
+
+	body, err := json.Marshal(domain.CommitInfo{EnrichedAt: "2026-07-27T00:00:00Z"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	repo := repomocks.NewMockRepository(t)
+	tx := repomocks.NewMockTx(t)
+	// Version 10 has a commit body that no longer parses; it must be skipped
+	// without stamping the marker so the batch reaches version 20.
+	repo.EXPECT().GetArtifactVersionByID(mock.Anything, int64(10)).
+		Return(db.ArtifactVersion{ID: 10, CommitBody: []byte("{not json")}, nil)
+	repo.EXPECT().GetArtifactVersionByID(mock.Anything, int64(20)).
+		Return(db.ArtifactVersion{ID: 20, CommitBody: body}, nil)
+	repo.EXPECT().WithTx(mock.Anything, mock.Anything).RunAndReturn(
+		func(ctx context.Context, fn func(repository.Tx) error) error {
+			return fn(tx)
+		},
+	).Once()
+	tx.EXPECT().GetArtifactVersionForUpdate(mock.Anything, int64(20)).
+		Return(db.ArtifactVersion{ID: 20, CommitBody: body}, nil)
+	tx.EXPECT().UpdateArtifactVersionCommitBody(mock.Anything, mock.Anything).Return(nil)
+
+	activities := &activity.GitHubAuthorResolutionActivities{Repo: repo}
+	env := newActivityEnv(t)
+	env.RegisterActivity(activities.ResolveGitHubAuthorsBatch)
+	if _, err := env.ExecuteActivity(
+		activities.ResolveGitHubAuthorsBatch,
+		activity.ResolveGitHubAuthorsBatchInput{VersionIDs: []int64{10, 20}},
+	); err != nil {
+		t.Fatalf("ResolveGitHubAuthorsBatch() error = %v", err)
+	}
+}
+
+func TestResolveGitHubAuthorsBatchRetriesTransientFailure(t *testing.T) {
+	t.Parallel()
+
+	body, err := json.Marshal(domain.CommitInfo{
+		Sha:        "head-sha",
+		Repository: "https://github.com/SpongePowered/Sponge",
+		EnrichedAt: "2026-07-27T00:00:00Z",
+		Author:     &domain.CommitAuthor{Name: "Git Author", Email: "author@example.com"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	repo := repomocks.NewMockRepository(t)
+	resolver := &fakeGitHubAuthorResolver{err: errors.New("github unavailable")}
+	repo.EXPECT().GetArtifactVersionByID(mock.Anything, int64(10)).
+		Return(db.ArtifactVersion{ID: 10, CommitBody: body}, nil)
+	repo.EXPECT().GetGitHubUserCache(mock.Anything, "author@example.com").
+		Return(db.GithubUserCache{}, pgx.ErrNoRows)
+
+	activities := &activity.GitHubAuthorResolutionActivities{Repo: repo, GitHub: resolver}
+	env := newActivityEnv(t)
+	env.RegisterActivity(activities.ResolveGitHubAuthorsBatch)
+	_, err = env.ExecuteActivity(
+		activities.ResolveGitHubAuthorsBatch,
+		activity.ResolveGitHubAuthorsBatchInput{VersionIDs: []int64{10}},
+	)
+	if err == nil {
+		t.Fatal("ResolveGitHubAuthorsBatch() error = nil, want retryable failure")
+	}
+	if !strings.Contains(err.Error(), "github unavailable") {
+		t.Fatalf("ResolveGitHubAuthorsBatch() error = %v", err)
 	}
 }
 

--- a/internal/activity/github_author_resolution_test.go
+++ b/internal/activity/github_author_resolution_test.go
@@ -1,0 +1,242 @@
+package activity_test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/stretchr/testify/mock"
+
+	"github.com/spongepowered/systemofadownload/internal/activity"
+	"github.com/spongepowered/systemofadownload/internal/db"
+	"github.com/spongepowered/systemofadownload/internal/domain"
+	"github.com/spongepowered/systemofadownload/internal/repository"
+	repomocks "github.com/spongepowered/systemofadownload/internal/repository/mocks"
+)
+
+type fakeGitHubAuthorResolver struct {
+	username string
+	err      error
+	calls    int
+}
+
+func (f *fakeGitHubAuthorResolver) ResolveUsername(
+	context.Context,
+	string,
+	string,
+	string,
+) (string, error) {
+	f.calls++
+	return f.username, f.err
+}
+
+func TestFetchGitHubAuthorResolutionPage(t *testing.T) {
+	t.Parallel()
+
+	repo := repomocks.NewMockRepository(t)
+	beforeID := int64(100)
+	repo.EXPECT().ListVersionsNeedingGitHubAuthorResolution(
+		t.Context(),
+		db.ListVersionsNeedingGitHubAuthorResolutionParams{
+			BeforeID: &beforeID,
+			PageSize: 50,
+		},
+	).Return([]int64{90, 80}, nil)
+
+	activities := &activity.GitHubAuthorResolutionActivities{Repo: repo}
+	got, err := activities.FetchGitHubAuthorResolutionPage(
+		t.Context(),
+		activity.FetchGitHubAuthorResolutionPageInput{
+			BeforeID: &beforeID,
+			PageSize: 50,
+		},
+	)
+	if err != nil {
+		t.Fatalf("FetchGitHubAuthorResolutionPage() error = %v", err)
+	}
+	if len(got.VersionIDs) != 2 || got.NextBeforeID == nil || *got.NextBeforeID != 80 {
+		t.Fatalf("FetchGitHubAuthorResolutionPage() = %#v", got)
+	}
+}
+
+func TestResolveGitHubAuthorsBatchUsesPersistentCacheAndLocksVersion(t *testing.T) {
+	t.Parallel()
+
+	cachedUsername := "cached-user"
+	info := domain.CommitInfo{
+		Sha:        "head-sha",
+		Repository: "https://github.com/SpongePowered/Sponge",
+		EnrichedAt: "2026-07-27T00:00:00Z",
+		Author: &domain.CommitAuthor{
+			Name:  "Cached Author",
+			Email: "cached@example.com",
+		},
+		Changelog: &domain.Changelog{
+			Commits: []domain.CommitSummary{{
+				Sha: "head-sha",
+				Author: &domain.CommitAuthor{
+					Name:  "Cached Author",
+					Email: "cached@example.com",
+				},
+			}},
+			SubmoduleChangelogs: map[string]*domain.Changelog{
+				"https://github.com/SpongePowered/SpongeAPI": {
+					Commits: []domain.CommitSummary{{
+						Sha: "sub-sha",
+						Author: &domain.CommitAuthor{
+							Name:  "Noreply Author",
+							Email: "123+noreply-user@users.noreply.github.com",
+						},
+					}},
+				},
+			},
+		},
+	}
+	body, err := json.Marshal(info)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	repo := repomocks.NewMockRepository(t)
+	tx := repomocks.NewMockTx(t)
+	resolver := &fakeGitHubAuthorResolver{}
+	repo.EXPECT().GetArtifactVersionByID(mock.Anything, int64(10)).
+		Return(db.ArtifactVersion{ID: 10, CommitBody: body}, nil)
+	repo.EXPECT().GetGitHubUserCache(mock.Anything, "cached@example.com").
+		Return(db.GithubUserCache{
+			AuthorEmail:    "cached@example.com",
+			GithubUsername: &cachedUsername,
+		}, nil)
+	repo.EXPECT().WithTx(mock.Anything, mock.Anything).RunAndReturn(
+		func(ctx context.Context, fn func(repository.Tx) error) error {
+			return fn(tx)
+		},
+	)
+	tx.EXPECT().GetArtifactVersionForUpdate(mock.Anything, int64(10)).
+		Return(db.ArtifactVersion{ID: 10, CommitBody: body}, nil)
+	tx.EXPECT().UpdateArtifactVersionCommitBody(mock.Anything, mock.MatchedBy(
+		func(params db.UpdateArtifactVersionCommitBodyParams) bool {
+			var updated domain.CommitInfo
+			if json.Unmarshal(params.CommitBody, &updated) != nil {
+				return false
+			}
+			nested := updated.Changelog.SubmoduleChangelogs["https://github.com/SpongePowered/SpongeAPI"]
+			return updated.Author.GitHubUsername == "cached-user" &&
+				updated.Changelog.Commits[0].Author.GitHubUsername == "cached-user" &&
+				nested.Commits[0].Author.GitHubUsername == "noreply-user" &&
+				updated.GitHubAuthorsResolvedAt != ""
+		},
+	)).Return(nil)
+
+	activities := &activity.GitHubAuthorResolutionActivities{
+		Repo:   repo,
+		GitHub: resolver,
+	}
+	env := newActivityEnv(t)
+	env.RegisterActivity(activities.ResolveGitHubAuthorsBatch)
+	_, err = env.ExecuteActivity(
+		activities.ResolveGitHubAuthorsBatch,
+		activity.ResolveGitHubAuthorsBatchInput{VersionIDs: []int64{10}},
+	)
+	if err != nil {
+		t.Fatalf("ResolveGitHubAuthorsBatch() error = %v", err)
+	}
+	if resolver.calls != 0 {
+		t.Errorf("GitHub API calls = %d, want 0", resolver.calls)
+	}
+}
+
+func TestResolveGitHubAuthorsBatchUsesGitHubOnCacheMiss(t *testing.T) {
+	t.Parallel()
+
+	info := domain.CommitInfo{
+		Sha:        "head-sha",
+		Repository: "https://github.com/SpongePowered/Sponge",
+		EnrichedAt: "2026-07-27T00:00:00Z",
+		Author: &domain.CommitAuthor{
+			Name:  "Git Author",
+			Email: "author@example.com",
+		},
+	}
+	body, _ := json.Marshal(info)
+
+	repo := repomocks.NewMockRepository(t)
+	tx := repomocks.NewMockTx(t)
+	resolver := &fakeGitHubAuthorResolver{username: "octocat"}
+	repo.EXPECT().GetArtifactVersionByID(mock.Anything, int64(10)).
+		Return(db.ArtifactVersion{ID: 10, CommitBody: body}, nil)
+	repo.EXPECT().GetGitHubUserCache(mock.Anything, "author@example.com").
+		Return(db.GithubUserCache{}, pgx.ErrNoRows)
+	repo.EXPECT().WithTx(mock.Anything, mock.Anything).RunAndReturn(
+		func(ctx context.Context, fn func(repository.Tx) error) error {
+			return fn(tx)
+		},
+	).Twice()
+	tx.EXPECT().UpsertGitHubUserCache(mock.Anything, mock.MatchedBy(
+		func(params db.UpsertGitHubUserCacheParams) bool {
+			return params.AuthorEmail == "author@example.com" &&
+				params.GithubUsername != nil &&
+				*params.GithubUsername == "octocat"
+		},
+	)).Return(db.GithubUserCache{}, nil)
+	tx.EXPECT().GetArtifactVersionForUpdate(mock.Anything, int64(10)).
+		Return(db.ArtifactVersion{ID: 10, CommitBody: body}, nil)
+	tx.EXPECT().UpdateArtifactVersionCommitBody(mock.Anything, mock.Anything).Return(nil)
+
+	activities := &activity.GitHubAuthorResolutionActivities{
+		Repo:   repo,
+		GitHub: resolver,
+	}
+	env := newActivityEnv(t)
+	env.RegisterActivity(activities.ResolveGitHubAuthorsBatch)
+	_, err := env.ExecuteActivity(
+		activities.ResolveGitHubAuthorsBatch,
+		activity.ResolveGitHubAuthorsBatchInput{VersionIDs: []int64{10}},
+	)
+	if err != nil {
+		t.Fatalf("ResolveGitHubAuthorsBatch() error = %v", err)
+	}
+	if resolver.calls != 1 {
+		t.Errorf("GitHub API calls = %d, want 1", resolver.calls)
+	}
+}
+
+func TestResolveGitHubAuthorsBatchResumesFromHeartbeat(t *testing.T) {
+	t.Parallel()
+
+	info := domain.CommitInfo{
+		EnrichedAt:              "2026-07-27T00:00:00Z",
+		GitHubAuthorsResolvedAt: "2026-07-27T01:00:00Z",
+	}
+	body, err := json.Marshal(info)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	repo := repomocks.NewMockRepository(t)
+	tx := repomocks.NewMockTx(t)
+	repo.EXPECT().GetArtifactVersionByID(mock.Anything, int64(20)).
+		Return(db.ArtifactVersion{ID: 20, CommitBody: body}, nil)
+	repo.EXPECT().WithTx(mock.Anything, mock.Anything).RunAndReturn(
+		func(ctx context.Context, fn func(repository.Tx) error) error {
+			return fn(tx)
+		},
+	)
+	tx.EXPECT().GetArtifactVersionForUpdate(mock.Anything, int64(20)).
+		Return(db.ArtifactVersion{ID: 20, CommitBody: body}, nil)
+
+	activities := &activity.GitHubAuthorResolutionActivities{Repo: repo}
+	env := newActivityEnv(t)
+	env.SetHeartbeatDetails(struct {
+		NextIndex int
+	}{NextIndex: 1})
+	env.RegisterActivity(activities.ResolveGitHubAuthorsBatch)
+	_, err = env.ExecuteActivity(
+		activities.ResolveGitHubAuthorsBatch,
+		activity.ResolveGitHubAuthorsBatchInput{VersionIDs: []int64{10, 20}},
+	)
+	if err != nil {
+		t.Fatalf("ResolveGitHubAuthorsBatch() error = %v", err)
+	}
+}

--- a/internal/db/mocks/db_mocks.go
+++ b/internal/db/mocks/db_mocks.go
@@ -880,53 +880,55 @@ func (_c *MockQuerier_GetArtifactVersionSchema_Call) RunAndReturn(run func(ctx c
 	return _c
 }
 
-// GetGitHubUserCache provides a mock function for the type MockQuerier
-func (_mock *MockQuerier) GetGitHubUserCache(ctx context.Context, authorEmail string) (db.GithubUserCache, error) {
-	ret := _mock.Called(ctx, authorEmail)
+// GetGitHubUserCacheBatch provides a mock function for the type MockQuerier
+func (_mock *MockQuerier) GetGitHubUserCacheBatch(ctx context.Context, authorEmails []string) ([]db.GithubUserCache, error) {
+	ret := _mock.Called(ctx, authorEmails)
 
 	if len(ret) == 0 {
-		panic("no return value specified for GetGitHubUserCache")
+		panic("no return value specified for GetGitHubUserCacheBatch")
 	}
 
-	var r0 db.GithubUserCache
+	var r0 []db.GithubUserCache
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string) (db.GithubUserCache, error)); ok {
-		return returnFunc(ctx, authorEmail)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, []string) ([]db.GithubUserCache, error)); ok {
+		return returnFunc(ctx, authorEmails)
 	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string) db.GithubUserCache); ok {
-		r0 = returnFunc(ctx, authorEmail)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, []string) []db.GithubUserCache); ok {
+		r0 = returnFunc(ctx, authorEmails)
 	} else {
-		r0 = ret.Get(0).(db.GithubUserCache)
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]db.GithubUserCache)
+		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, string) error); ok {
-		r1 = returnFunc(ctx, authorEmail)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, []string) error); ok {
+		r1 = returnFunc(ctx, authorEmails)
 	} else {
 		r1 = ret.Error(1)
 	}
 	return r0, r1
 }
 
-// MockQuerier_GetGitHubUserCache_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetGitHubUserCache'
-type MockQuerier_GetGitHubUserCache_Call struct {
+// MockQuerier_GetGitHubUserCacheBatch_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetGitHubUserCacheBatch'
+type MockQuerier_GetGitHubUserCacheBatch_Call struct {
 	*mock.Call
 }
 
-// GetGitHubUserCache is a helper method to define mock.On call
+// GetGitHubUserCacheBatch is a helper method to define mock.On call
 //   - ctx context.Context
-//   - authorEmail string
-func (_e *MockQuerier_Expecter) GetGitHubUserCache(ctx interface{}, authorEmail interface{}) *MockQuerier_GetGitHubUserCache_Call {
-	return &MockQuerier_GetGitHubUserCache_Call{Call: _e.mock.On("GetGitHubUserCache", ctx, authorEmail)}
+//   - authorEmails []string
+func (_e *MockQuerier_Expecter) GetGitHubUserCacheBatch(ctx interface{}, authorEmails interface{}) *MockQuerier_GetGitHubUserCacheBatch_Call {
+	return &MockQuerier_GetGitHubUserCacheBatch_Call{Call: _e.mock.On("GetGitHubUserCacheBatch", ctx, authorEmails)}
 }
 
-func (_c *MockQuerier_GetGitHubUserCache_Call) Run(run func(ctx context.Context, authorEmail string)) *MockQuerier_GetGitHubUserCache_Call {
+func (_c *MockQuerier_GetGitHubUserCacheBatch_Call) Run(run func(ctx context.Context, authorEmails []string)) *MockQuerier_GetGitHubUserCacheBatch_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
 			arg0 = args[0].(context.Context)
 		}
-		var arg1 string
+		var arg1 []string
 		if args[1] != nil {
-			arg1 = args[1].(string)
+			arg1 = args[1].([]string)
 		}
 		run(
 			arg0,
@@ -936,12 +938,12 @@ func (_c *MockQuerier_GetGitHubUserCache_Call) Run(run func(ctx context.Context,
 	return _c
 }
 
-func (_c *MockQuerier_GetGitHubUserCache_Call) Return(githubUserCache db.GithubUserCache, err error) *MockQuerier_GetGitHubUserCache_Call {
-	_c.Call.Return(githubUserCache, err)
+func (_c *MockQuerier_GetGitHubUserCacheBatch_Call) Return(githubUserCaches []db.GithubUserCache, err error) *MockQuerier_GetGitHubUserCacheBatch_Call {
+	_c.Call.Return(githubUserCaches, err)
 	return _c
 }
 
-func (_c *MockQuerier_GetGitHubUserCache_Call) RunAndReturn(run func(ctx context.Context, authorEmail string) (db.GithubUserCache, error)) *MockQuerier_GetGitHubUserCache_Call {
+func (_c *MockQuerier_GetGitHubUserCacheBatch_Call) RunAndReturn(run func(ctx context.Context, authorEmails []string) ([]db.GithubUserCache, error)) *MockQuerier_GetGitHubUserCacheBatch_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/db/mocks/db_mocks.go
+++ b/internal/db/mocks/db_mocks.go
@@ -746,6 +746,72 @@ func (_c *MockQuerier_GetArtifactVersionByID_Call) RunAndReturn(run func(ctx con
 	return _c
 }
 
+// GetArtifactVersionForUpdate provides a mock function for the type MockQuerier
+func (_mock *MockQuerier) GetArtifactVersionForUpdate(ctx context.Context, id int64) (db.ArtifactVersion, error) {
+	ret := _mock.Called(ctx, id)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetArtifactVersionForUpdate")
+	}
+
+	var r0 db.ArtifactVersion
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, int64) (db.ArtifactVersion, error)); ok {
+		return returnFunc(ctx, id)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, int64) db.ArtifactVersion); ok {
+		r0 = returnFunc(ctx, id)
+	} else {
+		r0 = ret.Get(0).(db.ArtifactVersion)
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, int64) error); ok {
+		r1 = returnFunc(ctx, id)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockQuerier_GetArtifactVersionForUpdate_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetArtifactVersionForUpdate'
+type MockQuerier_GetArtifactVersionForUpdate_Call struct {
+	*mock.Call
+}
+
+// GetArtifactVersionForUpdate is a helper method to define mock.On call
+//   - ctx context.Context
+//   - id int64
+func (_e *MockQuerier_Expecter) GetArtifactVersionForUpdate(ctx interface{}, id interface{}) *MockQuerier_GetArtifactVersionForUpdate_Call {
+	return &MockQuerier_GetArtifactVersionForUpdate_Call{Call: _e.mock.On("GetArtifactVersionForUpdate", ctx, id)}
+}
+
+func (_c *MockQuerier_GetArtifactVersionForUpdate_Call) Run(run func(ctx context.Context, id int64)) *MockQuerier_GetArtifactVersionForUpdate_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 int64
+		if args[1] != nil {
+			arg1 = args[1].(int64)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *MockQuerier_GetArtifactVersionForUpdate_Call) Return(artifactVersion db.ArtifactVersion, err error) *MockQuerier_GetArtifactVersionForUpdate_Call {
+	_c.Call.Return(artifactVersion, err)
+	return _c
+}
+
+func (_c *MockQuerier_GetArtifactVersionForUpdate_Call) RunAndReturn(run func(ctx context.Context, id int64) (db.ArtifactVersion, error)) *MockQuerier_GetArtifactVersionForUpdate_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetArtifactVersionSchema provides a mock function for the type MockQuerier
 func (_mock *MockQuerier) GetArtifactVersionSchema(ctx context.Context, arg db.GetArtifactVersionSchemaParams) ([]byte, error) {
 	ret := _mock.Called(ctx, arg)
@@ -810,6 +876,72 @@ func (_c *MockQuerier_GetArtifactVersionSchema_Call) Return(bytes []byte, err er
 }
 
 func (_c *MockQuerier_GetArtifactVersionSchema_Call) RunAndReturn(run func(ctx context.Context, arg db.GetArtifactVersionSchemaParams) ([]byte, error)) *MockQuerier_GetArtifactVersionSchema_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// GetGitHubUserCache provides a mock function for the type MockQuerier
+func (_mock *MockQuerier) GetGitHubUserCache(ctx context.Context, authorEmail string) (db.GithubUserCache, error) {
+	ret := _mock.Called(ctx, authorEmail)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetGitHubUserCache")
+	}
+
+	var r0 db.GithubUserCache
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) (db.GithubUserCache, error)); ok {
+		return returnFunc(ctx, authorEmail)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) db.GithubUserCache); ok {
+		r0 = returnFunc(ctx, authorEmail)
+	} else {
+		r0 = ret.Get(0).(db.GithubUserCache)
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = returnFunc(ctx, authorEmail)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockQuerier_GetGitHubUserCache_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetGitHubUserCache'
+type MockQuerier_GetGitHubUserCache_Call struct {
+	*mock.Call
+}
+
+// GetGitHubUserCache is a helper method to define mock.On call
+//   - ctx context.Context
+//   - authorEmail string
+func (_e *MockQuerier_Expecter) GetGitHubUserCache(ctx interface{}, authorEmail interface{}) *MockQuerier_GetGitHubUserCache_Call {
+	return &MockQuerier_GetGitHubUserCache_Call{Call: _e.mock.On("GetGitHubUserCache", ctx, authorEmail)}
+}
+
+func (_c *MockQuerier_GetGitHubUserCache_Call) Run(run func(ctx context.Context, authorEmail string)) *MockQuerier_GetGitHubUserCache_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *MockQuerier_GetGitHubUserCache_Call) Return(githubUserCache db.GithubUserCache, err error) *MockQuerier_GetGitHubUserCache_Call {
+	_c.Call.Return(githubUserCache, err)
+	return _c
+}
+
+func (_c *MockQuerier_GetGitHubUserCache_Call) RunAndReturn(run func(ctx context.Context, authorEmail string) (db.GithubUserCache, error)) *MockQuerier_GetGitHubUserCache_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -2011,6 +2143,74 @@ func (_c *MockQuerier_ListVersionsNeedingEnrichment_Call) RunAndReturn(run func(
 	return _c
 }
 
+// ListVersionsNeedingGitHubAuthorResolution provides a mock function for the type MockQuerier
+func (_mock *MockQuerier) ListVersionsNeedingGitHubAuthorResolution(ctx context.Context, arg db.ListVersionsNeedingGitHubAuthorResolutionParams) ([]int64, error) {
+	ret := _mock.Called(ctx, arg)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ListVersionsNeedingGitHubAuthorResolution")
+	}
+
+	var r0 []int64
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, db.ListVersionsNeedingGitHubAuthorResolutionParams) ([]int64, error)); ok {
+		return returnFunc(ctx, arg)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, db.ListVersionsNeedingGitHubAuthorResolutionParams) []int64); ok {
+		r0 = returnFunc(ctx, arg)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]int64)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, db.ListVersionsNeedingGitHubAuthorResolutionParams) error); ok {
+		r1 = returnFunc(ctx, arg)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockQuerier_ListVersionsNeedingGitHubAuthorResolution_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ListVersionsNeedingGitHubAuthorResolution'
+type MockQuerier_ListVersionsNeedingGitHubAuthorResolution_Call struct {
+	*mock.Call
+}
+
+// ListVersionsNeedingGitHubAuthorResolution is a helper method to define mock.On call
+//   - ctx context.Context
+//   - arg db.ListVersionsNeedingGitHubAuthorResolutionParams
+func (_e *MockQuerier_Expecter) ListVersionsNeedingGitHubAuthorResolution(ctx interface{}, arg interface{}) *MockQuerier_ListVersionsNeedingGitHubAuthorResolution_Call {
+	return &MockQuerier_ListVersionsNeedingGitHubAuthorResolution_Call{Call: _e.mock.On("ListVersionsNeedingGitHubAuthorResolution", ctx, arg)}
+}
+
+func (_c *MockQuerier_ListVersionsNeedingGitHubAuthorResolution_Call) Run(run func(ctx context.Context, arg db.ListVersionsNeedingGitHubAuthorResolutionParams)) *MockQuerier_ListVersionsNeedingGitHubAuthorResolution_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 db.ListVersionsNeedingGitHubAuthorResolutionParams
+		if args[1] != nil {
+			arg1 = args[1].(db.ListVersionsNeedingGitHubAuthorResolutionParams)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *MockQuerier_ListVersionsNeedingGitHubAuthorResolution_Call) Return(int64s []int64, err error) *MockQuerier_ListVersionsNeedingGitHubAuthorResolution_Call {
+	_c.Call.Return(int64s, err)
+	return _c
+}
+
+func (_c *MockQuerier_ListVersionsNeedingGitHubAuthorResolution_Call) RunAndReturn(run func(ctx context.Context, arg db.ListVersionsNeedingGitHubAuthorResolutionParams) ([]int64, error)) *MockQuerier_ListVersionsNeedingGitHubAuthorResolution_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // UpdateArtifactFields provides a mock function for the type MockQuerier
 func (_mock *MockQuerier) UpdateArtifactFields(ctx context.Context, arg db.UpdateArtifactFieldsParams) (db.Artifact, error) {
 	ret := _mock.Called(ctx, arg)
@@ -2244,6 +2444,72 @@ func (_c *MockQuerier_UpdateArtifactVersionSchema_Call) Return(err error) *MockQ
 }
 
 func (_c *MockQuerier_UpdateArtifactVersionSchema_Call) RunAndReturn(run func(ctx context.Context, arg db.UpdateArtifactVersionSchemaParams) error) *MockQuerier_UpdateArtifactVersionSchema_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// UpsertGitHubUserCache provides a mock function for the type MockQuerier
+func (_mock *MockQuerier) UpsertGitHubUserCache(ctx context.Context, arg db.UpsertGitHubUserCacheParams) (db.GithubUserCache, error) {
+	ret := _mock.Called(ctx, arg)
+
+	if len(ret) == 0 {
+		panic("no return value specified for UpsertGitHubUserCache")
+	}
+
+	var r0 db.GithubUserCache
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, db.UpsertGitHubUserCacheParams) (db.GithubUserCache, error)); ok {
+		return returnFunc(ctx, arg)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, db.UpsertGitHubUserCacheParams) db.GithubUserCache); ok {
+		r0 = returnFunc(ctx, arg)
+	} else {
+		r0 = ret.Get(0).(db.GithubUserCache)
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, db.UpsertGitHubUserCacheParams) error); ok {
+		r1 = returnFunc(ctx, arg)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockQuerier_UpsertGitHubUserCache_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'UpsertGitHubUserCache'
+type MockQuerier_UpsertGitHubUserCache_Call struct {
+	*mock.Call
+}
+
+// UpsertGitHubUserCache is a helper method to define mock.On call
+//   - ctx context.Context
+//   - arg db.UpsertGitHubUserCacheParams
+func (_e *MockQuerier_Expecter) UpsertGitHubUserCache(ctx interface{}, arg interface{}) *MockQuerier_UpsertGitHubUserCache_Call {
+	return &MockQuerier_UpsertGitHubUserCache_Call{Call: _e.mock.On("UpsertGitHubUserCache", ctx, arg)}
+}
+
+func (_c *MockQuerier_UpsertGitHubUserCache_Call) Run(run func(ctx context.Context, arg db.UpsertGitHubUserCacheParams)) *MockQuerier_UpsertGitHubUserCache_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 db.UpsertGitHubUserCacheParams
+		if args[1] != nil {
+			arg1 = args[1].(db.UpsertGitHubUserCacheParams)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *MockQuerier_UpsertGitHubUserCache_Call) Return(githubUserCache db.GithubUserCache, err error) *MockQuerier_UpsertGitHubUserCache_Call {
+	_c.Call.Return(githubUserCache, err)
+	return _c
+}
+
+func (_c *MockQuerier_UpsertGitHubUserCache_Call) RunAndReturn(run func(ctx context.Context, arg db.UpsertGitHubUserCacheParams) (db.GithubUserCache, error)) *MockQuerier_UpsertGitHubUserCache_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -4,6 +4,10 @@
 
 package db
 
+import (
+	"github.com/jackc/pgx/v5/pgtype"
+)
+
 type Artifact struct {
 	ID              int64
 	GroupID         string
@@ -40,6 +44,13 @@ type ArtifactVersionedTag struct {
 	ArtifactVersionID int64
 	TagKey            string
 	TagValue          string
+}
+
+type GithubUserCache struct {
+	AuthorEmail    string
+	GithubUsername *string
+	ExpiresAt      pgtype.Timestamptz
+	UpdatedAt      pgtype.Timestamptz
 }
 
 type Group struct {

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -34,7 +34,7 @@ type Querier interface {
 	GetArtifactVersionByID(ctx context.Context, id int64) (ArtifactVersion, error)
 	GetArtifactVersionForUpdate(ctx context.Context, id int64) (ArtifactVersion, error)
 	GetArtifactVersionSchema(ctx context.Context, arg GetArtifactVersionSchemaParams) ([]byte, error)
-	GetGitHubUserCache(ctx context.Context, authorEmail string) (GithubUserCache, error)
+	GetGitHubUserCacheBatch(ctx context.Context, authorEmails []string) ([]GithubUserCache, error)
 	GetGroup(ctx context.Context, mavenID string) (Group, error)
 	GetPreviousVersion(ctx context.Context, arg GetPreviousVersionParams) (ArtifactVersion, error)
 	// Returns the artifact_version row plus its assets and tags pre-aggregated
@@ -65,6 +65,9 @@ type Querier interface {
 	ListTagsForVersions(ctx context.Context, dollar_1 []int64) ([]ArtifactVersionedTag, error)
 	ListVersionsNeedingChangelog(ctx context.Context, arg ListVersionsNeedingChangelogParams) ([]ArtifactVersion, error)
 	ListVersionsNeedingEnrichment(ctx context.Context, arg ListVersionsNeedingEnrichmentParams) ([]ArtifactVersion, error)
+	// The predicate must stay identical to idx_versions_github_authors_unresolved,
+	// including the literal schema version, or the partial index is not used.
+	// Guarded by TestAuthorResolutionSchemaMatchesSQL.
 	ListVersionsNeedingGitHubAuthorResolution(ctx context.Context, arg ListVersionsNeedingGitHubAuthorResolutionParams) ([]int64, error)
 	UpdateArtifactFields(ctx context.Context, arg UpdateArtifactFieldsParams) (Artifact, error)
 	UpdateArtifactVersionCommitBody(ctx context.Context, arg UpdateArtifactVersionCommitBodyParams) error

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -32,7 +32,9 @@ type Querier interface {
 	GetArtifactByGroupAndId(ctx context.Context, arg GetArtifactByGroupAndIdParams) (Artifact, error)
 	GetArtifactVersion(ctx context.Context, arg GetArtifactVersionParams) (ArtifactVersion, error)
 	GetArtifactVersionByID(ctx context.Context, id int64) (ArtifactVersion, error)
+	GetArtifactVersionForUpdate(ctx context.Context, id int64) (ArtifactVersion, error)
 	GetArtifactVersionSchema(ctx context.Context, arg GetArtifactVersionSchemaParams) ([]byte, error)
+	GetGitHubUserCache(ctx context.Context, authorEmail string) (GithubUserCache, error)
 	GetGroup(ctx context.Context, mavenID string) (Group, error)
 	GetPreviousVersion(ctx context.Context, arg GetPreviousVersionParams) (ArtifactVersion, error)
 	// Returns the artifact_version row plus its assets and tags pre-aggregated
@@ -63,10 +65,12 @@ type Querier interface {
 	ListTagsForVersions(ctx context.Context, dollar_1 []int64) ([]ArtifactVersionedTag, error)
 	ListVersionsNeedingChangelog(ctx context.Context, arg ListVersionsNeedingChangelogParams) ([]ArtifactVersion, error)
 	ListVersionsNeedingEnrichment(ctx context.Context, arg ListVersionsNeedingEnrichmentParams) ([]ArtifactVersion, error)
+	ListVersionsNeedingGitHubAuthorResolution(ctx context.Context, arg ListVersionsNeedingGitHubAuthorResolutionParams) ([]int64, error)
 	UpdateArtifactFields(ctx context.Context, arg UpdateArtifactFieldsParams) (Artifact, error)
 	UpdateArtifactVersionCommitBody(ctx context.Context, arg UpdateArtifactVersionCommitBodyParams) error
 	UpdateArtifactVersionOrder(ctx context.Context, arg UpdateArtifactVersionOrderParams) error
 	UpdateArtifactVersionSchema(ctx context.Context, arg UpdateArtifactVersionSchemaParams) error
+	UpsertGitHubUserCache(ctx context.Context, arg UpsertGitHubUserCacheParams) (GithubUserCache, error)
 }
 
 var _ Querier = (*Queries)(nil)

--- a/internal/db/query.sql.go
+++ b/internal/db/query.sql.go
@@ -8,6 +8,7 @@ package db
 import (
 	"context"
 
+	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/spongepowered/systemofadownload/internal/dbtypes"
 )
 
@@ -309,6 +310,26 @@ func (q *Queries) GetArtifactVersionByID(ctx context.Context, id int64) (Artifac
 	return i, err
 }
 
+const getArtifactVersionForUpdate = `-- name: GetArtifactVersionForUpdate :one
+SELECT id, artifact_id, version, sort_order, recommended, commit_body FROM artifact_versions
+WHERE id = $1
+FOR UPDATE
+`
+
+func (q *Queries) GetArtifactVersionForUpdate(ctx context.Context, id int64) (ArtifactVersion, error) {
+	row := q.db.QueryRow(ctx, getArtifactVersionForUpdate, id)
+	var i ArtifactVersion
+	err := row.Scan(
+		&i.ID,
+		&i.ArtifactID,
+		&i.Version,
+		&i.SortOrder,
+		&i.Recommended,
+		&i.CommitBody,
+	)
+	return i, err
+}
+
 const getArtifactVersionSchema = `-- name: GetArtifactVersionSchema :one
 SELECT version_schema FROM artifacts
 WHERE group_id = $1 AND artifact_id = $2
@@ -324,6 +345,24 @@ func (q *Queries) GetArtifactVersionSchema(ctx context.Context, arg GetArtifactV
 	var version_schema []byte
 	err := row.Scan(&version_schema)
 	return version_schema, err
+}
+
+const getGitHubUserCache = `-- name: GetGitHubUserCache :one
+SELECT author_email, github_username, expires_at, updated_at FROM github_user_cache
+WHERE author_email = LOWER(BTRIM($1))
+  AND expires_at > NOW()
+`
+
+func (q *Queries) GetGitHubUserCache(ctx context.Context, authorEmail string) (GithubUserCache, error) {
+	row := q.db.QueryRow(ctx, getGitHubUserCache, authorEmail)
+	var i GithubUserCache
+	err := row.Scan(
+		&i.AuthorEmail,
+		&i.GithubUsername,
+		&i.ExpiresAt,
+		&i.UpdatedAt,
+	)
+	return i, err
 }
 
 const getGroup = `-- name: GetGroup :one
@@ -920,6 +959,42 @@ func (q *Queries) ListVersionsNeedingEnrichment(ctx context.Context, arg ListVer
 	return items, nil
 }
 
+const listVersionsNeedingGitHubAuthorResolution = `-- name: ListVersionsNeedingGitHubAuthorResolution :many
+SELECT id
+FROM artifact_versions
+WHERE commit_body IS NOT NULL
+  AND commit_body->>'enrichedAt' IS NOT NULL
+  AND commit_body->>'githubAuthorsResolvedAt' IS NULL
+  AND ($1::bigint IS NULL OR id < $1)
+ORDER BY id DESC
+LIMIT $2
+`
+
+type ListVersionsNeedingGitHubAuthorResolutionParams struct {
+	BeforeID *int64
+	PageSize int32
+}
+
+func (q *Queries) ListVersionsNeedingGitHubAuthorResolution(ctx context.Context, arg ListVersionsNeedingGitHubAuthorResolutionParams) ([]int64, error) {
+	rows, err := q.db.Query(ctx, listVersionsNeedingGitHubAuthorResolution, arg.BeforeID, arg.PageSize)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []int64
+	for rows.Next() {
+		var id int64
+		if err := rows.Scan(&id); err != nil {
+			return nil, err
+		}
+		items = append(items, id)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const updateArtifactFields = `-- name: UpdateArtifactFields :one
 UPDATE artifacts SET
   name = COALESCE($3, name),
@@ -1009,4 +1084,36 @@ type UpdateArtifactVersionSchemaParams struct {
 func (q *Queries) UpdateArtifactVersionSchema(ctx context.Context, arg UpdateArtifactVersionSchemaParams) error {
 	_, err := q.db.Exec(ctx, updateArtifactVersionSchema, arg.GroupID, arg.ArtifactID, arg.VersionSchema)
 	return err
+}
+
+const upsertGitHubUserCache = `-- name: UpsertGitHubUserCache :one
+INSERT INTO github_user_cache (author_email, github_username, expires_at)
+VALUES (
+    LOWER(BTRIM($1)),
+    $2,
+    $3
+)
+ON CONFLICT (author_email) DO UPDATE SET
+    github_username = EXCLUDED.github_username,
+    expires_at = EXCLUDED.expires_at,
+    updated_at = NOW()
+RETURNING author_email, github_username, expires_at, updated_at
+`
+
+type UpsertGitHubUserCacheParams struct {
+	AuthorEmail    string
+	GithubUsername *string
+	ExpiresAt      pgtype.Timestamptz
+}
+
+func (q *Queries) UpsertGitHubUserCache(ctx context.Context, arg UpsertGitHubUserCacheParams) (GithubUserCache, error) {
+	row := q.db.QueryRow(ctx, upsertGitHubUserCache, arg.AuthorEmail, arg.GithubUsername, arg.ExpiresAt)
+	var i GithubUserCache
+	err := row.Scan(
+		&i.AuthorEmail,
+		&i.GithubUsername,
+		&i.ExpiresAt,
+		&i.UpdatedAt,
+	)
+	return i, err
 }

--- a/internal/db/query.sql.go
+++ b/internal/db/query.sql.go
@@ -347,22 +347,35 @@ func (q *Queries) GetArtifactVersionSchema(ctx context.Context, arg GetArtifactV
 	return version_schema, err
 }
 
-const getGitHubUserCache = `-- name: GetGitHubUserCache :one
+const getGitHubUserCacheBatch = `-- name: GetGitHubUserCacheBatch :many
 SELECT author_email, github_username, expires_at, updated_at FROM github_user_cache
-WHERE author_email = LOWER(BTRIM($1))
+WHERE author_email = ANY($1::text[])
   AND expires_at > NOW()
 `
 
-func (q *Queries) GetGitHubUserCache(ctx context.Context, authorEmail string) (GithubUserCache, error) {
-	row := q.db.QueryRow(ctx, getGitHubUserCache, authorEmail)
-	var i GithubUserCache
-	err := row.Scan(
-		&i.AuthorEmail,
-		&i.GithubUsername,
-		&i.ExpiresAt,
-		&i.UpdatedAt,
-	)
-	return i, err
+func (q *Queries) GetGitHubUserCacheBatch(ctx context.Context, authorEmails []string) ([]GithubUserCache, error) {
+	rows, err := q.db.Query(ctx, getGitHubUserCacheBatch, authorEmails)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []GithubUserCache
+	for rows.Next() {
+		var i GithubUserCache
+		if err := rows.Scan(
+			&i.AuthorEmail,
+			&i.GithubUsername,
+			&i.ExpiresAt,
+			&i.UpdatedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
 }
 
 const getGroup = `-- name: GetGroup :one
@@ -962,9 +975,8 @@ func (q *Queries) ListVersionsNeedingEnrichment(ctx context.Context, arg ListVer
 const listVersionsNeedingGitHubAuthorResolution = `-- name: ListVersionsNeedingGitHubAuthorResolution :many
 SELECT id
 FROM artifact_versions
-WHERE commit_body IS NOT NULL
-  AND commit_body->>'enrichedAt' IS NOT NULL
-  AND commit_body->>'githubAuthorsResolvedAt' IS NULL
+WHERE commit_body->>'enrichedAt' IS NOT NULL
+  AND (commit_body->'authorResolution'->>'schema') IS DISTINCT FROM '1'
   AND ($1::bigint IS NULL OR id < $1)
 ORDER BY id DESC
 LIMIT $2
@@ -975,6 +987,9 @@ type ListVersionsNeedingGitHubAuthorResolutionParams struct {
 	PageSize int32
 }
 
+// The predicate must stay identical to idx_versions_github_authors_unresolved,
+// including the literal schema version, or the partial index is not used.
+// Guarded by TestAuthorResolutionSchemaMatchesSQL.
 func (q *Queries) ListVersionsNeedingGitHubAuthorResolution(ctx context.Context, arg ListVersionsNeedingGitHubAuthorResolutionParams) ([]int64, error) {
 	rows, err := q.db.Query(ctx, listVersionsNeedingGitHubAuthorResolution, arg.BeforeID, arg.PageSize)
 	if err != nil {

--- a/internal/domain/asset.go
+++ b/internal/domain/asset.go
@@ -42,6 +42,8 @@ type CommitInfo struct {
 	Submodules []SubmoduleCommit `json:"submodules,omitempty"`
 	Changelog  *Changelog        `json:"changelog,omitempty"`
 	EnrichedAt string            `json:"enrichedAt,omitempty"`
+	// GitHubAuthorsResolvedAt marks completion of durable author resolution.
+	GitHubAuthorsResolvedAt string `json:"githubAuthorsResolvedAt,omitempty"`
 
 	// ChangelogStatus tracks pending changelog computation.
 	// "pending_predecessor" means N-1 was not yet enriched.

--- a/internal/domain/asset.go
+++ b/internal/domain/asset.go
@@ -42,8 +42,8 @@ type CommitInfo struct {
 	Submodules []SubmoduleCommit `json:"submodules,omitempty"`
 	Changelog  *Changelog        `json:"changelog,omitempty"`
 	EnrichedAt string            `json:"enrichedAt,omitempty"`
-	// GitHubAuthorsResolvedAt marks completion of durable author resolution.
-	GitHubAuthorsResolvedAt string `json:"githubAuthorsResolvedAt,omitempty"`
+	// AuthorResolution marks completion of durable GitHub author resolution.
+	AuthorResolution *AuthorResolution `json:"authorResolution,omitempty"`
 
 	// ChangelogStatus tracks pending changelog computation.
 	// "pending_predecessor" means N-1 was not yet enriched.
@@ -55,6 +55,24 @@ type CommitAuthor struct {
 	Name           string `json:"name"`
 	Email          string `json:"email"`
 	GitHubUsername string `json:"githubUsername,omitempty"`
+}
+
+// AuthorResolutionSchema is the current GitHub author resolution logic version.
+// Versions carrying an older schema are treated as stale and resolved again.
+//
+// Bumping this requires a migration that replaces
+// idx_versions_github_authors_unresolved, because the partial index predicate
+// hard-codes the value so the keyset scan stays indexed.
+// TestAuthorResolutionSchemaMatchesSQL enforces this.
+const AuthorResolutionSchema = 1
+
+// AuthorResolution records the outcome of a GitHub author resolution pass over
+// a version's commit body.
+type AuthorResolution struct {
+	At string `json:"at"`
+	// Unresolved counts author entries with no associated GitHub account.
+	Unresolved int `json:"unresolved"`
+	Schema     int `json:"schema"`
 }
 
 // SubmoduleCommit holds commit details for a submodule at a specific version.

--- a/internal/domain/asset.go
+++ b/internal/domain/asset.go
@@ -50,8 +50,9 @@ type CommitInfo struct {
 
 // CommitAuthor holds the name and email of a git commit author.
 type CommitAuthor struct {
-	Name  string `json:"name"`
-	Email string `json:"email"`
+	Name           string `json:"name"`
+	Email          string `json:"email"`
+	GitHubUsername string `json:"githubUsername,omitempty"`
 }
 
 // SubmoduleCommit holds commit details for a submodule at a specific version.

--- a/internal/domain/author_resolution_test.go
+++ b/internal/domain/author_resolution_test.go
@@ -1,0 +1,62 @@
+package domain_test
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"testing"
+
+	"github.com/spongepowered/systemofadownload/internal/domain"
+)
+
+// authorResolutionPredicate matches the schema literal shared by the keyset
+// query and the partial index that has to serve it.
+var authorResolutionPredicate = regexp.MustCompile(
+	`\(commit_body->'authorResolution'->>'schema'\)\s+IS DISTINCT FROM\s+'(\d+)'`,
+)
+
+// TestAuthorResolutionSchemaMatchesSQL keeps domain.AuthorResolutionSchema in
+// lockstep with the SQL that depends on it.
+//
+// A partial index predicate cannot be parameterised, so the schema version is a
+// literal in both ListVersionsNeedingGitHubAuthorResolution and
+// idx_versions_github_authors_unresolved. Drift is silent and harmful in both
+// directions:
+//
+//   - Bumping the constant without updating the SQL means versions carrying the
+//     old schema are never selected, so the re-resolution never happens, while
+//     already-current versions are selected on every tick and skipped, churning
+//     the whole history every 2 minutes.
+//   - Updating the query without a migration that replaces the index leaves the
+//     predicates unable to imply one another, so the keyset scan quietly stops
+//     being indexed.
+func TestAuthorResolutionSchemaMatchesSQL(t *testing.T) {
+	t.Parallel()
+
+	want := strconv.Itoa(domain.AuthorResolutionSchema)
+	// db/schema.sql mirrors the cumulative schema, so it stands in for the
+	// current index definition. Applied migrations are immutable history and
+	// are deliberately not checked.
+	for _, name := range []string{"query.sql", "schema.sql"} {
+		path := filepath.Join("..", "..", "db", name)
+		content, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("reading %s: %v", path, err)
+		}
+
+		matches := authorResolutionPredicate.FindAllStringSubmatch(string(content), -1)
+		if len(matches) == 0 {
+			t.Fatalf("%s: author resolution schema predicate not found; "+
+				"if the predicate changed shape, update authorResolutionPredicate", path)
+		}
+		for _, match := range matches {
+			if match[1] != want {
+				t.Errorf("%s: schema literal is '%s', want '%s' from "+
+					"domain.AuthorResolutionSchema; bumping the constant also needs a "+
+					"migration replacing idx_versions_github_authors_unresolved",
+					path, match[1], want)
+			}
+		}
+	}
+}

--- a/internal/frontend/commits.go
+++ b/internal/frontend/commits.go
@@ -12,6 +12,7 @@ type CommitEntry struct {
 	Message      string
 	Body         string
 	Author       string
+	AuthorLink   string
 	RelativeTime string
 	AbsoluteTime string
 	Link         string

--- a/internal/frontend/commits_test.go
+++ b/internal/frontend/commits_test.go
@@ -1,0 +1,32 @@
+package frontend
+
+import (
+	"testing"
+
+	"github.com/spongepowered/systemofadownload/internal/domain"
+)
+
+func TestCommitAuthorDisplay(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		author   *domain.CommitAuthor
+		wantName string
+		wantLink string
+	}{
+		{name: "GitHub username preferred", author: &domain.CommitAuthor{Name: "Mona Lisa", GitHubUsername: "octocat"}, wantName: "octocat", wantLink: "https://github.com/octocat"},
+		{name: "Git name fallback", author: &domain.CommitAuthor{Name: "Mona Lisa"}, wantName: "Mona Lisa"},
+		{name: "unknown author", wantName: "Unknown"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			name, link := commitAuthorDisplay(tt.author)
+			if name != tt.wantName || link != tt.wantLink {
+				t.Errorf("commitAuthorDisplay() = (%q, %q), want (%q, %q)", name, link, tt.wantName, tt.wantLink)
+			}
+		})
+	}
+}

--- a/internal/frontend/handlers.go
+++ b/internal/frontend/handlers.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"net/url"
 	"strconv"
 	"strings"
 	"sync"
@@ -429,10 +430,12 @@ func parseCommitBody(raw []byte) ([]CommitEntry, []SubmoduleChangelog, bool) {
 		if link == "" && info.Repository != "" && info.Sha != "" {
 			link = domain.CommitURL(info.Repository, info.Sha)
 		}
+		author, authorLink := commitAuthorDisplay(info.Author)
 		entry := CommitEntry{
-			Message: info.Message,
-			Author:  commitAuthorName(info.Author),
-			Link:    link,
+			Message:    info.Message,
+			Author:     author,
+			AuthorLink: authorLink,
+			Link:       link,
 		}
 		entry.Body = deduplicateCommitBody(entry.Message, info.Body)
 		entry.HasBody = entry.Body != ""
@@ -490,10 +493,12 @@ func parseCommitBody(raw []byte) ([]CommitEntry, []SubmoduleChangelog, bool) {
 }
 
 func commitSummaryToEntry(cs *domain.CommitSummary) CommitEntry {
+	author, authorLink := commitAuthorDisplay(cs.Author)
 	entry := CommitEntry{
-		Message: cs.Message,
-		Author:  commitAuthorName(cs.Author),
-		Link:    cs.URL,
+		Message:    cs.Message,
+		Author:     author,
+		AuthorLink: authorLink,
+		Link:       cs.URL,
 	}
 	// CommitSummary doesn't have a separate body field
 	entry.HasBody = false
@@ -508,11 +513,14 @@ func commitSummaryToEntry(cs *domain.CommitSummary) CommitEntry {
 	return entry
 }
 
-func commitAuthorName(author *domain.CommitAuthor) string {
+func commitAuthorDisplay(author *domain.CommitAuthor) (name, link string) {
 	if author == nil {
-		return "Unknown"
+		return "Unknown", ""
 	}
-	return author.Name
+	if author.GitHubUsername != "" {
+		return author.GitHubUsername, "https://github.com/" + url.PathEscape(author.GitHubUsername)
+	}
+	return author.Name, ""
 }
 
 // parseSubmoduleChangelogs converts the map of repo URL -> Changelog into

--- a/internal/frontend/templates/downloads.gohtml
+++ b/internal/frontend/templates/downloads.gohtml
@@ -118,7 +118,7 @@
                     <pre class="commit-message">{{$c.Body}}</pre>
                   </details>
                   {{end}}
-                  <div>{{$c.Author}}{{if $c.RelativeTime}} - <small title="{{$c.AbsoluteTime}}">{{$c.RelativeTime}}</small>{{end}}</div>
+                  <div>{{if $c.AuthorLink}}<a href="{{$c.AuthorLink}}" target="_blank" rel="noopener noreferrer">{{$c.Author}}</a>{{else}}{{$c.Author}}{{end}}{{if $c.RelativeTime}} - <small title="{{$c.AbsoluteTime}}">{{$c.RelativeTime}}</small>{{end}}</div>
                 </li>
                 {{end}}
                 {{if gt (len .Commits) 5}}
@@ -144,7 +144,7 @@
                   <li class="commit">
                     {{if .Link}}<a href="{{.Link}}" target="_blank">{{.Message}}</a>
                     {{else}}{{.Message}}{{end}}
-                    <div>{{.Author}}{{if .RelativeTime}} - <small title="{{.AbsoluteTime}}">{{.RelativeTime}}</small>{{end}}</div>
+                    <div>{{if .AuthorLink}}<a href="{{.AuthorLink}}" target="_blank" rel="noopener noreferrer">{{.Author}}</a>{{else}}{{.Author}}{{end}}{{if .RelativeTime}} - <small title="{{.AbsoluteTime}}">{{.RelativeTime}}</small>{{end}}</div>
                   </li>
                   {{end}}
                 </ol>

--- a/internal/githubapi/client.go
+++ b/internal/githubapi/client.go
@@ -9,24 +9,30 @@ import (
 	"net/url"
 	"path"
 	"regexp"
+	"strconv"
 	"strings"
-	"sync"
+	"time"
 )
 
 const defaultBaseURL = "https://api.github.com"
 
 var githubUsernamePattern = regexp.MustCompile(`^[A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?$`)
 
-type cacheEntry struct {
-	username string
-}
-
 // Client resolves Git commit authors to their associated GitHub usernames.
 type Client struct {
 	httpClient *http.Client
 	baseURL    string
 	token      string
-	cache      sync.Map
+}
+
+// RateLimitError reports when GitHub asks callers to wait until a reset time.
+type RateLimitError struct {
+	ResetAt time.Time
+	Message string
+}
+
+func (e *RateLimitError) Error() string {
+	return e.Message
 }
 
 // NewClient creates a GitHub API client. The token is optional for public repositories.
@@ -53,21 +59,9 @@ func (c *Client) ResolveUsername(ctx context.Context, repoURL, sha, email string
 		return username, nil
 	}
 
-	emailKey := "email:" + strings.ToLower(strings.TrimSpace(email))
-	if emailKey != "email:" {
-		if cached, ok := c.cache.Load(emailKey); ok {
-			return cached.(cacheEntry).username, nil
-		}
-	}
-
 	owner, repo, ok := ParseRepository(repoURL)
 	if !ok || strings.TrimSpace(sha) == "" {
 		return "", nil
-	}
-
-	cacheKey := strings.ToLower(owner + "/" + repo + "@" + sha)
-	if cached, ok := c.cache.Load(cacheKey); ok {
-		return cached.(cacheEntry).username, nil
 	}
 
 	endpoint := fmt.Sprintf(
@@ -97,12 +91,20 @@ func (c *Client) ResolveUsername(ctx context.Context, repoURL, sha, email string
 	}()
 
 	if resp.StatusCode == http.StatusNotFound {
-		c.cache.Store(cacheKey, cacheEntry{})
 		return "", nil
 	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		body, _ := io.ReadAll(io.LimitReader(resp.Body, 4<<10))
-		return "", fmt.Errorf("GitHub commit lookup returned %s: %s", resp.Status, strings.TrimSpace(string(body)))
+		message := fmt.Sprintf("GitHub commit lookup returned %s: %s", resp.Status, strings.TrimSpace(string(body)))
+		if resp.StatusCode == http.StatusForbidden || resp.StatusCode == http.StatusTooManyRequests {
+			if reset, err := strconv.ParseInt(resp.Header.Get("X-RateLimit-Reset"), 10, 64); err == nil {
+				return "", &RateLimitError{
+					ResetAt: time.Unix(reset, 0),
+					Message: message,
+				}
+			}
+		}
+		return "", fmt.Errorf("%s", message)
 	}
 
 	var result struct {
@@ -117,10 +119,6 @@ func (c *Client) ResolveUsername(ctx context.Context, repoURL, sha, email string
 	username := ""
 	if result.Author != nil {
 		username = result.Author.Login
-	}
-	c.cache.Store(cacheKey, cacheEntry{username: username})
-	if username != "" && emailKey != "email:" {
-		c.cache.Store(emailKey, cacheEntry{username: username})
 	}
 	return username, nil
 }

--- a/internal/githubapi/client.go
+++ b/internal/githubapi/client.go
@@ -1,0 +1,168 @@
+package githubapi
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"path"
+	"regexp"
+	"strings"
+	"sync"
+)
+
+const defaultBaseURL = "https://api.github.com"
+
+var githubUsernamePattern = regexp.MustCompile(`^[A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?$`)
+
+type cacheEntry struct {
+	username string
+}
+
+// Client resolves Git commit authors to their associated GitHub usernames.
+type Client struct {
+	httpClient *http.Client
+	baseURL    string
+	token      string
+	cache      sync.Map
+}
+
+// NewClient creates a GitHub API client. The token is optional for public repositories.
+func NewClient(httpClient *http.Client, token string) *Client {
+	return NewClientWithBaseURL(httpClient, token, defaultBaseURL)
+}
+
+// NewClientWithBaseURL creates a client with a custom API base URL.
+func NewClientWithBaseURL(httpClient *http.Client, token, baseURL string) *Client {
+	if httpClient == nil {
+		httpClient = http.DefaultClient
+	}
+	return &Client{
+		httpClient: httpClient,
+		baseURL:    strings.TrimRight(baseURL, "/"),
+		token:      strings.TrimSpace(token),
+	}
+}
+
+// ResolveUsername returns the GitHub account associated with a commit author.
+// An empty username with a nil error means GitHub has no associated account.
+func (c *Client) ResolveUsername(ctx context.Context, repoURL, sha, email string) (string, error) {
+	if username := UsernameFromNoreplyEmail(email); username != "" {
+		return username, nil
+	}
+
+	emailKey := "email:" + strings.ToLower(strings.TrimSpace(email))
+	if emailKey != "email:" {
+		if cached, ok := c.cache.Load(emailKey); ok {
+			return cached.(cacheEntry).username, nil
+		}
+	}
+
+	owner, repo, ok := ParseRepository(repoURL)
+	if !ok || strings.TrimSpace(sha) == "" {
+		return "", nil
+	}
+
+	cacheKey := strings.ToLower(owner + "/" + repo + "@" + sha)
+	if cached, ok := c.cache.Load(cacheKey); ok {
+		return cached.(cacheEntry).username, nil
+	}
+
+	endpoint := fmt.Sprintf(
+		"%s/repos/%s/%s/commits/%s",
+		c.baseURL,
+		url.PathEscape(owner),
+		url.PathEscape(repo),
+		url.PathEscape(sha),
+	)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, http.NoBody)
+	if err != nil {
+		return "", fmt.Errorf("creating GitHub commit request: %w", err)
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("User-Agent", "SystemOfADownload")
+	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+	if c.token != "" {
+		req.Header.Set("Authorization", "Bearer "+c.token)
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("requesting GitHub commit: %w", err)
+	}
+	defer func() {
+		_ = resp.Body.Close()
+	}()
+
+	if resp.StatusCode == http.StatusNotFound {
+		c.cache.Store(cacheKey, cacheEntry{})
+		return "", nil
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 4<<10))
+		return "", fmt.Errorf("GitHub commit lookup returned %s: %s", resp.Status, strings.TrimSpace(string(body)))
+	}
+
+	var result struct {
+		Author *struct {
+			Login string `json:"login"`
+		} `json:"author"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return "", fmt.Errorf("decoding GitHub commit response: %w", err)
+	}
+
+	username := ""
+	if result.Author != nil {
+		username = result.Author.Login
+	}
+	c.cache.Store(cacheKey, cacheEntry{username: username})
+	if username != "" && emailKey != "email:" {
+		c.cache.Store(emailKey, cacheEntry{username: username})
+	}
+	return username, nil
+}
+
+// UsernameFromNoreplyEmail extracts a username from GitHub's noreply address formats.
+func UsernameFromNoreplyEmail(email string) string {
+	parts := strings.Split(strings.TrimSpace(email), "@")
+	if len(parts) != 2 || !strings.EqualFold(parts[1], "users.noreply.github.com") {
+		return ""
+	}
+
+	username := parts[0]
+	if _, suffix, found := strings.Cut(username, "+"); found {
+		username = suffix
+	}
+	if !githubUsernamePattern.MatchString(username) {
+		return ""
+	}
+	return username
+}
+
+// ParseRepository extracts an owner and repository from a GitHub repository or commit URL.
+func ParseRepository(rawURL string) (owner, repo string, ok bool) {
+	rawURL = strings.TrimSpace(rawURL)
+	if strings.HasPrefix(rawURL, "git@github.com:") {
+		rawURL = "https://github.com/" + strings.TrimPrefix(rawURL, "git@github.com:")
+	}
+
+	parsed, err := url.Parse(rawURL)
+	if err != nil || !strings.EqualFold(parsed.Hostname(), "github.com") {
+		return "", "", false
+	}
+
+	segments := strings.Split(strings.Trim(path.Clean(parsed.Path), "/"), "/")
+	if len(segments) < 2 {
+		return "", "", false
+	}
+
+	owner = segments[0]
+	repo = strings.TrimSuffix(segments[1], ".git")
+	if owner == "" || repo == "" {
+		return "", "", false
+	}
+	return owner, repo, true
+}

--- a/internal/githubapi/client_test.go
+++ b/internal/githubapi/client_test.go
@@ -1,6 +1,7 @@
 package githubapi_test
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -81,23 +82,21 @@ func TestClientResolveUsername(t *testing.T) {
 	defer server.Close()
 
 	client := githubapi.NewClientWithBaseURL(server.Client(), "test-token", server.URL)
-	for range 2 {
-		username, err := client.ResolveUsername(
-			t.Context(),
-			"https://github.com/SpongePowered/Sponge",
-			"abc123",
-			"developer@example.com",
-		)
-		if err != nil {
-			t.Fatalf("ResolveUsername() error = %v", err)
-		}
-		if username != "octocat" {
-			t.Errorf("ResolveUsername() = %q, want octocat", username)
-		}
+	username, err := client.ResolveUsername(
+		t.Context(),
+		"https://github.com/SpongePowered/Sponge",
+		"abc123",
+		"developer@example.com",
+	)
+	if err != nil {
+		t.Fatalf("ResolveUsername() error = %v", err)
+	}
+	if username != "octocat" {
+		t.Errorf("ResolveUsername() = %q, want octocat", username)
 	}
 
 	if got := requests.Load(); got != 1 {
-		t.Errorf("request count = %d, want 1 cached request", got)
+		t.Errorf("request count = %d, want 1 request", got)
 	}
 }
 
@@ -120,6 +119,9 @@ func TestClientResolveUsernameFallbacks(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				if tt.name == "rate limited" {
+					w.Header().Set("X-RateLimit-Reset", "2000000000")
+				}
 				w.WriteHeader(tt.statusCode)
 				_, _ = fmt.Fprint(w, tt.body)
 			}))
@@ -137,6 +139,12 @@ func TestClientResolveUsernameFallbacks(t *testing.T) {
 			}
 			if got != tt.want {
 				t.Errorf("ResolveUsername() = %q, want %q", got, tt.want)
+			}
+			if tt.name == "rate limited" {
+				var rateLimitErr *githubapi.RateLimitError
+				if !errors.As(err, &rateLimitErr) {
+					t.Fatalf("error = %T, want *githubapi.RateLimitError", err)
+				}
 			}
 		})
 	}

--- a/internal/githubapi/client_test.go
+++ b/internal/githubapi/client_test.go
@@ -1,0 +1,143 @@
+package githubapi_test
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/spongepowered/systemofadownload/internal/githubapi"
+)
+
+func TestUsernameFromNoreplyEmail(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		email string
+		want  string
+	}{
+		{name: "modern address", email: "12345+octocat@users.noreply.github.com", want: "octocat"},
+		{name: "legacy address", email: "octocat@users.noreply.github.com", want: "octocat"},
+		{name: "case insensitive domain", email: "octocat@USERS.NOREPLY.GITHUB.COM", want: "octocat"},
+		{name: "ordinary email", email: "octocat@example.com"},
+		{name: "invalid username", email: "-invalid@users.noreply.github.com"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := githubapi.UsernameFromNoreplyEmail(tt.email); got != tt.want {
+				t.Errorf("UsernameFromNoreplyEmail() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseRepository(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		rawURL    string
+		wantOwner string
+		wantRepo  string
+		wantOK    bool
+	}{
+		{name: "HTTPS repository", rawURL: "https://github.com/SpongePowered/Sponge.git", wantOwner: "SpongePowered", wantRepo: "Sponge", wantOK: true},
+		{name: "commit URL", rawURL: "https://github.com/SpongePowered/Sponge/commit/abc123", wantOwner: "SpongePowered", wantRepo: "Sponge", wantOK: true},
+		{name: "SSH repository", rawURL: "git@github.com:SpongePowered/Sponge.git", wantOwner: "SpongePowered", wantRepo: "Sponge", wantOK: true},
+		{name: "non GitHub repository", rawURL: "https://gitlab.com/example/project"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			owner, repo, ok := githubapi.ParseRepository(tt.rawURL)
+			if owner != tt.wantOwner || repo != tt.wantRepo || ok != tt.wantOK {
+				t.Errorf("ParseRepository() = (%q, %q, %v), want (%q, %q, %v)",
+					owner, repo, ok, tt.wantOwner, tt.wantRepo, tt.wantOK)
+			}
+		})
+	}
+}
+
+func TestClientResolveUsername(t *testing.T) {
+	t.Parallel()
+
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests.Add(1)
+		if got := r.Header.Get("Authorization"); got != "Bearer test-token" {
+			t.Errorf("Authorization = %q, want bearer token", got)
+		}
+		if r.URL.Path != "/repos/SpongePowered/Sponge/commits/abc123" {
+			t.Errorf("path = %q", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, `{"author":{"login":"octocat"}}`)
+	}))
+	defer server.Close()
+
+	client := githubapi.NewClientWithBaseURL(server.Client(), "test-token", server.URL)
+	for range 2 {
+		username, err := client.ResolveUsername(
+			t.Context(),
+			"https://github.com/SpongePowered/Sponge",
+			"abc123",
+			"developer@example.com",
+		)
+		if err != nil {
+			t.Fatalf("ResolveUsername() error = %v", err)
+		}
+		if username != "octocat" {
+			t.Errorf("ResolveUsername() = %q, want octocat", username)
+		}
+	}
+
+	if got := requests.Load(); got != 1 {
+		t.Errorf("request count = %d, want 1 cached request", got)
+	}
+}
+
+func TestClientResolveUsernameFallbacks(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		statusCode int
+		body       string
+		want       string
+		wantErr    bool
+	}{
+		{name: "unassociated commit", statusCode: http.StatusOK, body: `{"author":null}`},
+		{name: "commit not found", statusCode: http.StatusNotFound},
+		{name: "rate limited", statusCode: http.StatusForbidden, body: `{"message":"rate limit exceeded"}`, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(tt.statusCode)
+				_, _ = fmt.Fprint(w, tt.body)
+			}))
+			defer server.Close()
+
+			client := githubapi.NewClientWithBaseURL(server.Client(), "", server.URL)
+			got, err := client.ResolveUsername(
+				t.Context(),
+				"https://github.com/SpongePowered/Sponge",
+				"abc123",
+				"developer@example.com",
+			)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("ResolveUsername() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if got != tt.want {
+				t.Errorf("ResolveUsername() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/httpapi/handler.go
+++ b/internal/httpapi/handler.go
@@ -855,11 +855,15 @@ func commitInfoToAPICommit(info *domain.CommitInfo) api.Commit {
 	}
 	if info.Author != nil {
 		c.Author = &struct {
-			Email *string `json:"email,omitempty"`
-			Name  *string `json:"name,omitempty"`
+			Email          *string `json:"email,omitempty"`
+			GithubUsername *string `json:"githubUsername,omitempty"`
+			Name           *string `json:"name,omitempty"`
 		}{
 			Name:  &info.Author.Name,
 			Email: &info.Author.Email,
+		}
+		if info.Author.GitHubUsername != "" {
+			c.Author.GithubUsername = &info.Author.GitHubUsername
 		}
 	}
 	return c
@@ -886,11 +890,15 @@ func commitSummaryToAPICommit(cs *domain.CommitSummary, repo string) *api.Commit
 	}
 	if cs.Author != nil {
 		c.Author = &struct {
-			Email *string `json:"email,omitempty"`
-			Name  *string `json:"name,omitempty"`
+			Email          *string `json:"email,omitempty"`
+			GithubUsername *string `json:"githubUsername,omitempty"`
+			Name           *string `json:"name,omitempty"`
 		}{
 			Name:  &cs.Author.Name,
 			Email: &cs.Author.Email,
+		}
+		if cs.Author.GitHubUsername != "" {
+			c.Author.GithubUsername = &cs.Author.GitHubUsername
 		}
 	}
 	return &c

--- a/internal/httpapi/handler.go
+++ b/internal/httpapi/handler.go
@@ -59,6 +59,11 @@ const versionSyncWorkflowExecutionTimeout = 30 * time.Minute
 
 // NewGitHubAuthorResolutionScheduleOptions returns the paused singleton
 // schedule used for durable GitHub author backfill and steady-state resolution.
+//
+// Unlike the version sync schedules this action deliberately sets no
+// WorkflowExecutionTimeout: that timeout spans the whole continue-as-new chain,
+// so any value would truncate the backfill mid-drain. The activity timeouts plus
+// the SKIP overlap policy bound a wedged run instead.
 func NewGitHubAuthorResolutionScheduleOptions() client.ScheduleOptions {
 	return client.ScheduleOptions{
 		ID: workflow.GitHubAuthorResolutionScheduleID,

--- a/internal/httpapi/handler.go
+++ b/internal/httpapi/handler.go
@@ -57,23 +57,27 @@ func VersionSyncScheduleID(groupID, artifactID string) string {
 // workflow cannot hide the schedule indefinitely.
 const versionSyncWorkflowExecutionTimeout = 30 * time.Minute
 
+// githubAuthorResolutionExecutionTimeout bounds an entire backfill chain, which
+// drains roughly 130 pages on its first unpaused run.
+const githubAuthorResolutionExecutionTimeout = 2 * time.Hour
+
 // NewGitHubAuthorResolutionScheduleOptions returns the paused singleton
 // schedule used for durable GitHub author backfill and steady-state resolution.
-//
-// Unlike the version sync schedules this action deliberately sets no
-// WorkflowExecutionTimeout: that timeout spans the whole continue-as-new chain,
-// so any value would truncate the backfill mid-drain. The activity timeouts plus
-// the SKIP overlap policy bound a wedged run instead.
 func NewGitHubAuthorResolutionScheduleOptions() client.ScheduleOptions {
 	return client.ScheduleOptions{
 		ID: workflow.GitHubAuthorResolutionScheduleID,
 		Spec: client.ScheduleSpec{
 			Intervals: []client.ScheduleIntervalSpec{{Every: 2 * time.Minute}},
+			Jitter:    15 * time.Second,
 		},
 		Action: &client.ScheduleWorkflowAction{
 			Workflow:  workflow.GitHubAuthorResolutionWorkflow,
 			Args:      []any{workflow.GitHubAuthorResolutionInput{}},
 			TaskQueue: workflow.VersionSyncTaskQueue,
+			// Bounds the whole continue-as-new chain, so a wedged backfill is
+			// abandoned and restarted from the newest page rather than running
+			// forever behind an Overlap: SKIP that hides every later tick.
+			WorkflowExecutionTimeout: githubAuthorResolutionExecutionTimeout,
 		},
 		Overlap: enumspb.SCHEDULE_OVERLAP_POLICY_SKIP,
 		Paused:  true,

--- a/internal/httpapi/handler.go
+++ b/internal/httpapi/handler.go
@@ -57,6 +57,25 @@ func VersionSyncScheduleID(groupID, artifactID string) string {
 // workflow cannot hide the schedule indefinitely.
 const versionSyncWorkflowExecutionTimeout = 30 * time.Minute
 
+// NewGitHubAuthorResolutionScheduleOptions returns the paused singleton
+// schedule used for durable GitHub author backfill and steady-state resolution.
+func NewGitHubAuthorResolutionScheduleOptions() client.ScheduleOptions {
+	return client.ScheduleOptions{
+		ID: workflow.GitHubAuthorResolutionScheduleID,
+		Spec: client.ScheduleSpec{
+			Intervals: []client.ScheduleIntervalSpec{{Every: 2 * time.Minute}},
+		},
+		Action: &client.ScheduleWorkflowAction{
+			Workflow:  workflow.GitHubAuthorResolutionWorkflow,
+			Args:      []any{workflow.GitHubAuthorResolutionInput{}},
+			TaskQueue: workflow.VersionSyncTaskQueue,
+		},
+		Overlap: enumspb.SCHEDULE_OVERLAP_POLICY_SKIP,
+		Paused:  true,
+		Note:    "Created paused; unpause after confirming GITHUB_TOKEN is configured",
+	}
+}
+
 // NewFastVersionSyncScheduleOptions returns the ScheduleOptions for the 2m
 // maven-metadata.xml schedule. Exposed for the migration binary.
 //

--- a/internal/httpapi/handler_test.go
+++ b/internal/httpapi/handler_test.go
@@ -10,6 +10,7 @@ import (
 	"slices"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/jackc/pgx/v5"
 	enumspb "go.temporal.io/api/enums/v1"
@@ -1297,6 +1298,7 @@ func TestVersionSyncScheduleID(t *testing.T) {
 			"version-sync-full-com.example-my-lib",
 		},
 	}
+
 	for _, tt := range tests {
 		t.Run(tt.groupID+"/"+tt.artifactID, func(t *testing.T) {
 			if got := VersionSyncScheduleID(tt.groupID, tt.artifactID); got != tt.wantLegacy {
@@ -1309,6 +1311,38 @@ func TestVersionSyncScheduleID(t *testing.T) {
 				t.Errorf("VersionSyncFullScheduleID = %q, want %q", got, tt.wantFull)
 			}
 		})
+	}
+}
+
+func TestGitHubAuthorResolutionScheduleOptions(t *testing.T) {
+	t.Parallel()
+
+	opts := NewGitHubAuthorResolutionScheduleOptions()
+	if opts.ID != workflow.GitHubAuthorResolutionScheduleID {
+		t.Errorf("ID = %q, want %q", opts.ID, workflow.GitHubAuthorResolutionScheduleID)
+	}
+	if !opts.Paused {
+		t.Error("schedule must be created paused")
+	}
+	if opts.Overlap != enumspb.SCHEDULE_OVERLAP_POLICY_SKIP {
+		t.Errorf("Overlap = %v, want SKIP", opts.Overlap)
+	}
+	if len(opts.Spec.Intervals) != 1 || opts.Spec.Intervals[0].Every != 2*time.Minute {
+		t.Errorf("Intervals = %#v, want one 2-minute interval", opts.Spec.Intervals)
+	}
+
+	action, ok := opts.Action.(*client.ScheduleWorkflowAction)
+	if !ok {
+		t.Fatalf("Action = %T, want *client.ScheduleWorkflowAction", opts.Action)
+	}
+	if action.TaskQueue != workflow.VersionSyncTaskQueue {
+		t.Errorf("TaskQueue = %q, want %q", action.TaskQueue, workflow.VersionSyncTaskQueue)
+	}
+	if len(action.Args) != 1 {
+		t.Fatalf("Args = %#v, want one workflow input", action.Args)
+	}
+	if _, ok := action.Args[0].(workflow.GitHubAuthorResolutionInput); !ok {
+		t.Errorf("Args[0] = %T, want GitHubAuthorResolutionInput", action.Args[0])
 	}
 }
 

--- a/internal/repository/mocks/repository_mocks.go
+++ b/internal/repository/mocks/repository_mocks.go
@@ -523,6 +523,72 @@ func (_c *MockReads_GetDistinctTagValues_Call) RunAndReturn(run func(ctx context
 	return _c
 }
 
+// GetGitHubUserCache provides a mock function for the type MockReads
+func (_mock *MockReads) GetGitHubUserCache(ctx context.Context, authorEmail string) (db.GithubUserCache, error) {
+	ret := _mock.Called(ctx, authorEmail)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetGitHubUserCache")
+	}
+
+	var r0 db.GithubUserCache
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) (db.GithubUserCache, error)); ok {
+		return returnFunc(ctx, authorEmail)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) db.GithubUserCache); ok {
+		r0 = returnFunc(ctx, authorEmail)
+	} else {
+		r0 = ret.Get(0).(db.GithubUserCache)
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = returnFunc(ctx, authorEmail)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockReads_GetGitHubUserCache_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetGitHubUserCache'
+type MockReads_GetGitHubUserCache_Call struct {
+	*mock.Call
+}
+
+// GetGitHubUserCache is a helper method to define mock.On call
+//   - ctx context.Context
+//   - authorEmail string
+func (_e *MockReads_Expecter) GetGitHubUserCache(ctx interface{}, authorEmail interface{}) *MockReads_GetGitHubUserCache_Call {
+	return &MockReads_GetGitHubUserCache_Call{Call: _e.mock.On("GetGitHubUserCache", ctx, authorEmail)}
+}
+
+func (_c *MockReads_GetGitHubUserCache_Call) Run(run func(ctx context.Context, authorEmail string)) *MockReads_GetGitHubUserCache_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *MockReads_GetGitHubUserCache_Call) Return(githubUserCache db.GithubUserCache, err error) *MockReads_GetGitHubUserCache_Call {
+	_c.Call.Return(githubUserCache, err)
+	return _c
+}
+
+func (_c *MockReads_GetGitHubUserCache_Call) RunAndReturn(run func(ctx context.Context, authorEmail string) (db.GithubUserCache, error)) *MockReads_GetGitHubUserCache_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetGroup provides a mock function for the type MockReads
 func (_mock *MockReads) GetGroup(ctx context.Context, mavenID string) (db.Group, error) {
 	ret := _mock.Called(ctx, mavenID)
@@ -1677,6 +1743,74 @@ func (_c *MockReads_ListVersionsNeedingEnrichment_Call) RunAndReturn(run func(ct
 	return _c
 }
 
+// ListVersionsNeedingGitHubAuthorResolution provides a mock function for the type MockReads
+func (_mock *MockReads) ListVersionsNeedingGitHubAuthorResolution(ctx context.Context, arg db.ListVersionsNeedingGitHubAuthorResolutionParams) ([]int64, error) {
+	ret := _mock.Called(ctx, arg)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ListVersionsNeedingGitHubAuthorResolution")
+	}
+
+	var r0 []int64
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, db.ListVersionsNeedingGitHubAuthorResolutionParams) ([]int64, error)); ok {
+		return returnFunc(ctx, arg)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, db.ListVersionsNeedingGitHubAuthorResolutionParams) []int64); ok {
+		r0 = returnFunc(ctx, arg)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]int64)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, db.ListVersionsNeedingGitHubAuthorResolutionParams) error); ok {
+		r1 = returnFunc(ctx, arg)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockReads_ListVersionsNeedingGitHubAuthorResolution_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ListVersionsNeedingGitHubAuthorResolution'
+type MockReads_ListVersionsNeedingGitHubAuthorResolution_Call struct {
+	*mock.Call
+}
+
+// ListVersionsNeedingGitHubAuthorResolution is a helper method to define mock.On call
+//   - ctx context.Context
+//   - arg db.ListVersionsNeedingGitHubAuthorResolutionParams
+func (_e *MockReads_Expecter) ListVersionsNeedingGitHubAuthorResolution(ctx interface{}, arg interface{}) *MockReads_ListVersionsNeedingGitHubAuthorResolution_Call {
+	return &MockReads_ListVersionsNeedingGitHubAuthorResolution_Call{Call: _e.mock.On("ListVersionsNeedingGitHubAuthorResolution", ctx, arg)}
+}
+
+func (_c *MockReads_ListVersionsNeedingGitHubAuthorResolution_Call) Run(run func(ctx context.Context, arg db.ListVersionsNeedingGitHubAuthorResolutionParams)) *MockReads_ListVersionsNeedingGitHubAuthorResolution_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 db.ListVersionsNeedingGitHubAuthorResolutionParams
+		if args[1] != nil {
+			arg1 = args[1].(db.ListVersionsNeedingGitHubAuthorResolutionParams)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *MockReads_ListVersionsNeedingGitHubAuthorResolution_Call) Return(int64s []int64, err error) *MockReads_ListVersionsNeedingGitHubAuthorResolution_Call {
+	_c.Call.Return(int64s, err)
+	return _c
+}
+
+func (_c *MockReads_ListVersionsNeedingGitHubAuthorResolution_Call) RunAndReturn(run func(ctx context.Context, arg db.ListVersionsNeedingGitHubAuthorResolutionParams) ([]int64, error)) *MockReads_ListVersionsNeedingGitHubAuthorResolution_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // ListVersionsWithAssets provides a mock function for the type MockReads
 func (_mock *MockReads) ListVersionsWithAssets(ctx context.Context, params repository.VersionQueryParams) (*repository.VersionsWithAssetsResult, error) {
 	ret := _mock.Called(ctx, params)
@@ -2216,6 +2350,72 @@ func (_c *MockWrites_DeleteArtifactVersionTags_Call) RunAndReturn(run func(ctx c
 	return _c
 }
 
+// GetArtifactVersionForUpdate provides a mock function for the type MockWrites
+func (_mock *MockWrites) GetArtifactVersionForUpdate(ctx context.Context, id int64) (db.ArtifactVersion, error) {
+	ret := _mock.Called(ctx, id)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetArtifactVersionForUpdate")
+	}
+
+	var r0 db.ArtifactVersion
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, int64) (db.ArtifactVersion, error)); ok {
+		return returnFunc(ctx, id)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, int64) db.ArtifactVersion); ok {
+		r0 = returnFunc(ctx, id)
+	} else {
+		r0 = ret.Get(0).(db.ArtifactVersion)
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, int64) error); ok {
+		r1 = returnFunc(ctx, id)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockWrites_GetArtifactVersionForUpdate_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetArtifactVersionForUpdate'
+type MockWrites_GetArtifactVersionForUpdate_Call struct {
+	*mock.Call
+}
+
+// GetArtifactVersionForUpdate is a helper method to define mock.On call
+//   - ctx context.Context
+//   - id int64
+func (_e *MockWrites_Expecter) GetArtifactVersionForUpdate(ctx interface{}, id interface{}) *MockWrites_GetArtifactVersionForUpdate_Call {
+	return &MockWrites_GetArtifactVersionForUpdate_Call{Call: _e.mock.On("GetArtifactVersionForUpdate", ctx, id)}
+}
+
+func (_c *MockWrites_GetArtifactVersionForUpdate_Call) Run(run func(ctx context.Context, id int64)) *MockWrites_GetArtifactVersionForUpdate_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 int64
+		if args[1] != nil {
+			arg1 = args[1].(int64)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *MockWrites_GetArtifactVersionForUpdate_Call) Return(artifactVersion db.ArtifactVersion, err error) *MockWrites_GetArtifactVersionForUpdate_Call {
+	_c.Call.Return(artifactVersion, err)
+	return _c
+}
+
+func (_c *MockWrites_GetArtifactVersionForUpdate_Call) RunAndReturn(run func(ctx context.Context, id int64) (db.ArtifactVersion, error)) *MockWrites_GetArtifactVersionForUpdate_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // InsertNewArtifactVersion provides a mock function for the type MockWrites
 func (_mock *MockWrites) InsertNewArtifactVersion(ctx context.Context, arg db.InsertNewArtifactVersionParams) error {
 	ret := _mock.Called(ctx, arg)
@@ -2506,6 +2706,72 @@ func (_c *MockWrites_UpdateArtifactVersionSchema_Call) Return(err error) *MockWr
 }
 
 func (_c *MockWrites_UpdateArtifactVersionSchema_Call) RunAndReturn(run func(ctx context.Context, arg db.UpdateArtifactVersionSchemaParams) error) *MockWrites_UpdateArtifactVersionSchema_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// UpsertGitHubUserCache provides a mock function for the type MockWrites
+func (_mock *MockWrites) UpsertGitHubUserCache(ctx context.Context, arg db.UpsertGitHubUserCacheParams) (db.GithubUserCache, error) {
+	ret := _mock.Called(ctx, arg)
+
+	if len(ret) == 0 {
+		panic("no return value specified for UpsertGitHubUserCache")
+	}
+
+	var r0 db.GithubUserCache
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, db.UpsertGitHubUserCacheParams) (db.GithubUserCache, error)); ok {
+		return returnFunc(ctx, arg)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, db.UpsertGitHubUserCacheParams) db.GithubUserCache); ok {
+		r0 = returnFunc(ctx, arg)
+	} else {
+		r0 = ret.Get(0).(db.GithubUserCache)
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, db.UpsertGitHubUserCacheParams) error); ok {
+		r1 = returnFunc(ctx, arg)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockWrites_UpsertGitHubUserCache_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'UpsertGitHubUserCache'
+type MockWrites_UpsertGitHubUserCache_Call struct {
+	*mock.Call
+}
+
+// UpsertGitHubUserCache is a helper method to define mock.On call
+//   - ctx context.Context
+//   - arg db.UpsertGitHubUserCacheParams
+func (_e *MockWrites_Expecter) UpsertGitHubUserCache(ctx interface{}, arg interface{}) *MockWrites_UpsertGitHubUserCache_Call {
+	return &MockWrites_UpsertGitHubUserCache_Call{Call: _e.mock.On("UpsertGitHubUserCache", ctx, arg)}
+}
+
+func (_c *MockWrites_UpsertGitHubUserCache_Call) Run(run func(ctx context.Context, arg db.UpsertGitHubUserCacheParams)) *MockWrites_UpsertGitHubUserCache_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 db.UpsertGitHubUserCacheParams
+		if args[1] != nil {
+			arg1 = args[1].(db.UpsertGitHubUserCacheParams)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *MockWrites_UpsertGitHubUserCache_Call) Return(githubUserCache db.GithubUserCache, err error) *MockWrites_UpsertGitHubUserCache_Call {
+	_c.Call.Return(githubUserCache, err)
+	return _c
+}
+
+func (_c *MockWrites_UpsertGitHubUserCache_Call) RunAndReturn(run func(ctx context.Context, arg db.UpsertGitHubUserCacheParams) (db.GithubUserCache, error)) *MockWrites_UpsertGitHubUserCache_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -3245,6 +3511,72 @@ func (_c *MockTx_GetArtifactVersionByID_Call) RunAndReturn(run func(ctx context.
 	return _c
 }
 
+// GetArtifactVersionForUpdate provides a mock function for the type MockTx
+func (_mock *MockTx) GetArtifactVersionForUpdate(ctx context.Context, id int64) (db.ArtifactVersion, error) {
+	ret := _mock.Called(ctx, id)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetArtifactVersionForUpdate")
+	}
+
+	var r0 db.ArtifactVersion
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, int64) (db.ArtifactVersion, error)); ok {
+		return returnFunc(ctx, id)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, int64) db.ArtifactVersion); ok {
+		r0 = returnFunc(ctx, id)
+	} else {
+		r0 = ret.Get(0).(db.ArtifactVersion)
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, int64) error); ok {
+		r1 = returnFunc(ctx, id)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockTx_GetArtifactVersionForUpdate_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetArtifactVersionForUpdate'
+type MockTx_GetArtifactVersionForUpdate_Call struct {
+	*mock.Call
+}
+
+// GetArtifactVersionForUpdate is a helper method to define mock.On call
+//   - ctx context.Context
+//   - id int64
+func (_e *MockTx_Expecter) GetArtifactVersionForUpdate(ctx interface{}, id interface{}) *MockTx_GetArtifactVersionForUpdate_Call {
+	return &MockTx_GetArtifactVersionForUpdate_Call{Call: _e.mock.On("GetArtifactVersionForUpdate", ctx, id)}
+}
+
+func (_c *MockTx_GetArtifactVersionForUpdate_Call) Run(run func(ctx context.Context, id int64)) *MockTx_GetArtifactVersionForUpdate_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 int64
+		if args[1] != nil {
+			arg1 = args[1].(int64)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *MockTx_GetArtifactVersionForUpdate_Call) Return(artifactVersion db.ArtifactVersion, err error) *MockTx_GetArtifactVersionForUpdate_Call {
+	_c.Call.Return(artifactVersion, err)
+	return _c
+}
+
+func (_c *MockTx_GetArtifactVersionForUpdate_Call) RunAndReturn(run func(ctx context.Context, id int64) (db.ArtifactVersion, error)) *MockTx_GetArtifactVersionForUpdate_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetArtifactVersionSchema provides a mock function for the type MockTx
 func (_mock *MockTx) GetArtifactVersionSchema(ctx context.Context, arg db.GetArtifactVersionSchemaParams) ([]byte, error) {
 	ret := _mock.Called(ctx, arg)
@@ -3461,6 +3793,72 @@ func (_c *MockTx_GetDistinctTagValues_Call) Return(stringToStrings map[string][]
 }
 
 func (_c *MockTx_GetDistinctTagValues_Call) RunAndReturn(run func(ctx context.Context, groupID string, artifactID string) (map[string][]string, error)) *MockTx_GetDistinctTagValues_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// GetGitHubUserCache provides a mock function for the type MockTx
+func (_mock *MockTx) GetGitHubUserCache(ctx context.Context, authorEmail string) (db.GithubUserCache, error) {
+	ret := _mock.Called(ctx, authorEmail)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetGitHubUserCache")
+	}
+
+	var r0 db.GithubUserCache
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) (db.GithubUserCache, error)); ok {
+		return returnFunc(ctx, authorEmail)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) db.GithubUserCache); ok {
+		r0 = returnFunc(ctx, authorEmail)
+	} else {
+		r0 = ret.Get(0).(db.GithubUserCache)
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = returnFunc(ctx, authorEmail)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockTx_GetGitHubUserCache_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetGitHubUserCache'
+type MockTx_GetGitHubUserCache_Call struct {
+	*mock.Call
+}
+
+// GetGitHubUserCache is a helper method to define mock.On call
+//   - ctx context.Context
+//   - authorEmail string
+func (_e *MockTx_Expecter) GetGitHubUserCache(ctx interface{}, authorEmail interface{}) *MockTx_GetGitHubUserCache_Call {
+	return &MockTx_GetGitHubUserCache_Call{Call: _e.mock.On("GetGitHubUserCache", ctx, authorEmail)}
+}
+
+func (_c *MockTx_GetGitHubUserCache_Call) Run(run func(ctx context.Context, authorEmail string)) *MockTx_GetGitHubUserCache_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *MockTx_GetGitHubUserCache_Call) Return(githubUserCache db.GithubUserCache, err error) *MockTx_GetGitHubUserCache_Call {
+	_c.Call.Return(githubUserCache, err)
+	return _c
+}
+
+func (_c *MockTx_GetGitHubUserCache_Call) RunAndReturn(run func(ctx context.Context, authorEmail string) (db.GithubUserCache, error)) *MockTx_GetGitHubUserCache_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -4676,6 +5074,74 @@ func (_c *MockTx_ListVersionsNeedingEnrichment_Call) RunAndReturn(run func(ctx c
 	return _c
 }
 
+// ListVersionsNeedingGitHubAuthorResolution provides a mock function for the type MockTx
+func (_mock *MockTx) ListVersionsNeedingGitHubAuthorResolution(ctx context.Context, arg db.ListVersionsNeedingGitHubAuthorResolutionParams) ([]int64, error) {
+	ret := _mock.Called(ctx, arg)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ListVersionsNeedingGitHubAuthorResolution")
+	}
+
+	var r0 []int64
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, db.ListVersionsNeedingGitHubAuthorResolutionParams) ([]int64, error)); ok {
+		return returnFunc(ctx, arg)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, db.ListVersionsNeedingGitHubAuthorResolutionParams) []int64); ok {
+		r0 = returnFunc(ctx, arg)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]int64)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, db.ListVersionsNeedingGitHubAuthorResolutionParams) error); ok {
+		r1 = returnFunc(ctx, arg)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockTx_ListVersionsNeedingGitHubAuthorResolution_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ListVersionsNeedingGitHubAuthorResolution'
+type MockTx_ListVersionsNeedingGitHubAuthorResolution_Call struct {
+	*mock.Call
+}
+
+// ListVersionsNeedingGitHubAuthorResolution is a helper method to define mock.On call
+//   - ctx context.Context
+//   - arg db.ListVersionsNeedingGitHubAuthorResolutionParams
+func (_e *MockTx_Expecter) ListVersionsNeedingGitHubAuthorResolution(ctx interface{}, arg interface{}) *MockTx_ListVersionsNeedingGitHubAuthorResolution_Call {
+	return &MockTx_ListVersionsNeedingGitHubAuthorResolution_Call{Call: _e.mock.On("ListVersionsNeedingGitHubAuthorResolution", ctx, arg)}
+}
+
+func (_c *MockTx_ListVersionsNeedingGitHubAuthorResolution_Call) Run(run func(ctx context.Context, arg db.ListVersionsNeedingGitHubAuthorResolutionParams)) *MockTx_ListVersionsNeedingGitHubAuthorResolution_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 db.ListVersionsNeedingGitHubAuthorResolutionParams
+		if args[1] != nil {
+			arg1 = args[1].(db.ListVersionsNeedingGitHubAuthorResolutionParams)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *MockTx_ListVersionsNeedingGitHubAuthorResolution_Call) Return(int64s []int64, err error) *MockTx_ListVersionsNeedingGitHubAuthorResolution_Call {
+	_c.Call.Return(int64s, err)
+	return _c
+}
+
+func (_c *MockTx_ListVersionsNeedingGitHubAuthorResolution_Call) RunAndReturn(run func(ctx context.Context, arg db.ListVersionsNeedingGitHubAuthorResolutionParams) ([]int64, error)) *MockTx_ListVersionsNeedingGitHubAuthorResolution_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // ListVersionsWithAssets provides a mock function for the type MockTx
 func (_mock *MockTx) ListVersionsWithAssets(ctx context.Context, params repository.VersionQueryParams) (*repository.VersionsWithAssetsResult, error) {
 	ret := _mock.Called(ctx, params)
@@ -4977,6 +5443,72 @@ func (_c *MockTx_UpdateArtifactVersionSchema_Call) Return(err error) *MockTx_Upd
 }
 
 func (_c *MockTx_UpdateArtifactVersionSchema_Call) RunAndReturn(run func(ctx context.Context, arg db.UpdateArtifactVersionSchemaParams) error) *MockTx_UpdateArtifactVersionSchema_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// UpsertGitHubUserCache provides a mock function for the type MockTx
+func (_mock *MockTx) UpsertGitHubUserCache(ctx context.Context, arg db.UpsertGitHubUserCacheParams) (db.GithubUserCache, error) {
+	ret := _mock.Called(ctx, arg)
+
+	if len(ret) == 0 {
+		panic("no return value specified for UpsertGitHubUserCache")
+	}
+
+	var r0 db.GithubUserCache
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, db.UpsertGitHubUserCacheParams) (db.GithubUserCache, error)); ok {
+		return returnFunc(ctx, arg)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, db.UpsertGitHubUserCacheParams) db.GithubUserCache); ok {
+		r0 = returnFunc(ctx, arg)
+	} else {
+		r0 = ret.Get(0).(db.GithubUserCache)
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, db.UpsertGitHubUserCacheParams) error); ok {
+		r1 = returnFunc(ctx, arg)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockTx_UpsertGitHubUserCache_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'UpsertGitHubUserCache'
+type MockTx_UpsertGitHubUserCache_Call struct {
+	*mock.Call
+}
+
+// UpsertGitHubUserCache is a helper method to define mock.On call
+//   - ctx context.Context
+//   - arg db.UpsertGitHubUserCacheParams
+func (_e *MockTx_Expecter) UpsertGitHubUserCache(ctx interface{}, arg interface{}) *MockTx_UpsertGitHubUserCache_Call {
+	return &MockTx_UpsertGitHubUserCache_Call{Call: _e.mock.On("UpsertGitHubUserCache", ctx, arg)}
+}
+
+func (_c *MockTx_UpsertGitHubUserCache_Call) Run(run func(ctx context.Context, arg db.UpsertGitHubUserCacheParams)) *MockTx_UpsertGitHubUserCache_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 db.UpsertGitHubUserCacheParams
+		if args[1] != nil {
+			arg1 = args[1].(db.UpsertGitHubUserCacheParams)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *MockTx_UpsertGitHubUserCache_Call) Return(githubUserCache db.GithubUserCache, err error) *MockTx_UpsertGitHubUserCache_Call {
+	_c.Call.Return(githubUserCache, err)
+	return _c
+}
+
+func (_c *MockTx_UpsertGitHubUserCache_Call) RunAndReturn(run func(ctx context.Context, arg db.UpsertGitHubUserCacheParams) (db.GithubUserCache, error)) *MockTx_UpsertGitHubUserCache_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -5488,6 +6020,72 @@ func (_c *MockRepository_GetDistinctTagValues_Call) Return(stringToStrings map[s
 }
 
 func (_c *MockRepository_GetDistinctTagValues_Call) RunAndReturn(run func(ctx context.Context, groupID string, artifactID string) (map[string][]string, error)) *MockRepository_GetDistinctTagValues_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// GetGitHubUserCache provides a mock function for the type MockRepository
+func (_mock *MockRepository) GetGitHubUserCache(ctx context.Context, authorEmail string) (db.GithubUserCache, error) {
+	ret := _mock.Called(ctx, authorEmail)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetGitHubUserCache")
+	}
+
+	var r0 db.GithubUserCache
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) (db.GithubUserCache, error)); ok {
+		return returnFunc(ctx, authorEmail)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) db.GithubUserCache); ok {
+		r0 = returnFunc(ctx, authorEmail)
+	} else {
+		r0 = ret.Get(0).(db.GithubUserCache)
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = returnFunc(ctx, authorEmail)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockRepository_GetGitHubUserCache_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetGitHubUserCache'
+type MockRepository_GetGitHubUserCache_Call struct {
+	*mock.Call
+}
+
+// GetGitHubUserCache is a helper method to define mock.On call
+//   - ctx context.Context
+//   - authorEmail string
+func (_e *MockRepository_Expecter) GetGitHubUserCache(ctx interface{}, authorEmail interface{}) *MockRepository_GetGitHubUserCache_Call {
+	return &MockRepository_GetGitHubUserCache_Call{Call: _e.mock.On("GetGitHubUserCache", ctx, authorEmail)}
+}
+
+func (_c *MockRepository_GetGitHubUserCache_Call) Run(run func(ctx context.Context, authorEmail string)) *MockRepository_GetGitHubUserCache_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *MockRepository_GetGitHubUserCache_Call) Return(githubUserCache db.GithubUserCache, err error) *MockRepository_GetGitHubUserCache_Call {
+	_c.Call.Return(githubUserCache, err)
+	return _c
+}
+
+func (_c *MockRepository_GetGitHubUserCache_Call) RunAndReturn(run func(ctx context.Context, authorEmail string) (db.GithubUserCache, error)) *MockRepository_GetGitHubUserCache_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -6642,6 +7240,74 @@ func (_c *MockRepository_ListVersionsNeedingEnrichment_Call) Return(artifactVers
 }
 
 func (_c *MockRepository_ListVersionsNeedingEnrichment_Call) RunAndReturn(run func(ctx context.Context, arg db.ListVersionsNeedingEnrichmentParams) ([]db.ArtifactVersion, error)) *MockRepository_ListVersionsNeedingEnrichment_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// ListVersionsNeedingGitHubAuthorResolution provides a mock function for the type MockRepository
+func (_mock *MockRepository) ListVersionsNeedingGitHubAuthorResolution(ctx context.Context, arg db.ListVersionsNeedingGitHubAuthorResolutionParams) ([]int64, error) {
+	ret := _mock.Called(ctx, arg)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ListVersionsNeedingGitHubAuthorResolution")
+	}
+
+	var r0 []int64
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, db.ListVersionsNeedingGitHubAuthorResolutionParams) ([]int64, error)); ok {
+		return returnFunc(ctx, arg)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, db.ListVersionsNeedingGitHubAuthorResolutionParams) []int64); ok {
+		r0 = returnFunc(ctx, arg)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]int64)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, db.ListVersionsNeedingGitHubAuthorResolutionParams) error); ok {
+		r1 = returnFunc(ctx, arg)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockRepository_ListVersionsNeedingGitHubAuthorResolution_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ListVersionsNeedingGitHubAuthorResolution'
+type MockRepository_ListVersionsNeedingGitHubAuthorResolution_Call struct {
+	*mock.Call
+}
+
+// ListVersionsNeedingGitHubAuthorResolution is a helper method to define mock.On call
+//   - ctx context.Context
+//   - arg db.ListVersionsNeedingGitHubAuthorResolutionParams
+func (_e *MockRepository_Expecter) ListVersionsNeedingGitHubAuthorResolution(ctx interface{}, arg interface{}) *MockRepository_ListVersionsNeedingGitHubAuthorResolution_Call {
+	return &MockRepository_ListVersionsNeedingGitHubAuthorResolution_Call{Call: _e.mock.On("ListVersionsNeedingGitHubAuthorResolution", ctx, arg)}
+}
+
+func (_c *MockRepository_ListVersionsNeedingGitHubAuthorResolution_Call) Run(run func(ctx context.Context, arg db.ListVersionsNeedingGitHubAuthorResolutionParams)) *MockRepository_ListVersionsNeedingGitHubAuthorResolution_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 db.ListVersionsNeedingGitHubAuthorResolutionParams
+		if args[1] != nil {
+			arg1 = args[1].(db.ListVersionsNeedingGitHubAuthorResolutionParams)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *MockRepository_ListVersionsNeedingGitHubAuthorResolution_Call) Return(int64s []int64, err error) *MockRepository_ListVersionsNeedingGitHubAuthorResolution_Call {
+	_c.Call.Return(int64s, err)
+	return _c
+}
+
+func (_c *MockRepository_ListVersionsNeedingGitHubAuthorResolution_Call) RunAndReturn(run func(ctx context.Context, arg db.ListVersionsNeedingGitHubAuthorResolutionParams) ([]int64, error)) *MockRepository_ListVersionsNeedingGitHubAuthorResolution_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/repository/mocks/repository_mocks.go
+++ b/internal/repository/mocks/repository_mocks.go
@@ -523,53 +523,55 @@ func (_c *MockReads_GetDistinctTagValues_Call) RunAndReturn(run func(ctx context
 	return _c
 }
 
-// GetGitHubUserCache provides a mock function for the type MockReads
-func (_mock *MockReads) GetGitHubUserCache(ctx context.Context, authorEmail string) (db.GithubUserCache, error) {
-	ret := _mock.Called(ctx, authorEmail)
+// GetGitHubUserCacheBatch provides a mock function for the type MockReads
+func (_mock *MockReads) GetGitHubUserCacheBatch(ctx context.Context, authorEmails []string) ([]db.GithubUserCache, error) {
+	ret := _mock.Called(ctx, authorEmails)
 
 	if len(ret) == 0 {
-		panic("no return value specified for GetGitHubUserCache")
+		panic("no return value specified for GetGitHubUserCacheBatch")
 	}
 
-	var r0 db.GithubUserCache
+	var r0 []db.GithubUserCache
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string) (db.GithubUserCache, error)); ok {
-		return returnFunc(ctx, authorEmail)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, []string) ([]db.GithubUserCache, error)); ok {
+		return returnFunc(ctx, authorEmails)
 	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string) db.GithubUserCache); ok {
-		r0 = returnFunc(ctx, authorEmail)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, []string) []db.GithubUserCache); ok {
+		r0 = returnFunc(ctx, authorEmails)
 	} else {
-		r0 = ret.Get(0).(db.GithubUserCache)
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]db.GithubUserCache)
+		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, string) error); ok {
-		r1 = returnFunc(ctx, authorEmail)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, []string) error); ok {
+		r1 = returnFunc(ctx, authorEmails)
 	} else {
 		r1 = ret.Error(1)
 	}
 	return r0, r1
 }
 
-// MockReads_GetGitHubUserCache_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetGitHubUserCache'
-type MockReads_GetGitHubUserCache_Call struct {
+// MockReads_GetGitHubUserCacheBatch_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetGitHubUserCacheBatch'
+type MockReads_GetGitHubUserCacheBatch_Call struct {
 	*mock.Call
 }
 
-// GetGitHubUserCache is a helper method to define mock.On call
+// GetGitHubUserCacheBatch is a helper method to define mock.On call
 //   - ctx context.Context
-//   - authorEmail string
-func (_e *MockReads_Expecter) GetGitHubUserCache(ctx interface{}, authorEmail interface{}) *MockReads_GetGitHubUserCache_Call {
-	return &MockReads_GetGitHubUserCache_Call{Call: _e.mock.On("GetGitHubUserCache", ctx, authorEmail)}
+//   - authorEmails []string
+func (_e *MockReads_Expecter) GetGitHubUserCacheBatch(ctx interface{}, authorEmails interface{}) *MockReads_GetGitHubUserCacheBatch_Call {
+	return &MockReads_GetGitHubUserCacheBatch_Call{Call: _e.mock.On("GetGitHubUserCacheBatch", ctx, authorEmails)}
 }
 
-func (_c *MockReads_GetGitHubUserCache_Call) Run(run func(ctx context.Context, authorEmail string)) *MockReads_GetGitHubUserCache_Call {
+func (_c *MockReads_GetGitHubUserCacheBatch_Call) Run(run func(ctx context.Context, authorEmails []string)) *MockReads_GetGitHubUserCacheBatch_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
 			arg0 = args[0].(context.Context)
 		}
-		var arg1 string
+		var arg1 []string
 		if args[1] != nil {
-			arg1 = args[1].(string)
+			arg1 = args[1].([]string)
 		}
 		run(
 			arg0,
@@ -579,12 +581,12 @@ func (_c *MockReads_GetGitHubUserCache_Call) Run(run func(ctx context.Context, a
 	return _c
 }
 
-func (_c *MockReads_GetGitHubUserCache_Call) Return(githubUserCache db.GithubUserCache, err error) *MockReads_GetGitHubUserCache_Call {
-	_c.Call.Return(githubUserCache, err)
+func (_c *MockReads_GetGitHubUserCacheBatch_Call) Return(githubUserCaches []db.GithubUserCache, err error) *MockReads_GetGitHubUserCacheBatch_Call {
+	_c.Call.Return(githubUserCaches, err)
 	return _c
 }
 
-func (_c *MockReads_GetGitHubUserCache_Call) RunAndReturn(run func(ctx context.Context, authorEmail string) (db.GithubUserCache, error)) *MockReads_GetGitHubUserCache_Call {
+func (_c *MockReads_GetGitHubUserCacheBatch_Call) RunAndReturn(run func(ctx context.Context, authorEmails []string) ([]db.GithubUserCache, error)) *MockReads_GetGitHubUserCacheBatch_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -3797,53 +3799,55 @@ func (_c *MockTx_GetDistinctTagValues_Call) RunAndReturn(run func(ctx context.Co
 	return _c
 }
 
-// GetGitHubUserCache provides a mock function for the type MockTx
-func (_mock *MockTx) GetGitHubUserCache(ctx context.Context, authorEmail string) (db.GithubUserCache, error) {
-	ret := _mock.Called(ctx, authorEmail)
+// GetGitHubUserCacheBatch provides a mock function for the type MockTx
+func (_mock *MockTx) GetGitHubUserCacheBatch(ctx context.Context, authorEmails []string) ([]db.GithubUserCache, error) {
+	ret := _mock.Called(ctx, authorEmails)
 
 	if len(ret) == 0 {
-		panic("no return value specified for GetGitHubUserCache")
+		panic("no return value specified for GetGitHubUserCacheBatch")
 	}
 
-	var r0 db.GithubUserCache
+	var r0 []db.GithubUserCache
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string) (db.GithubUserCache, error)); ok {
-		return returnFunc(ctx, authorEmail)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, []string) ([]db.GithubUserCache, error)); ok {
+		return returnFunc(ctx, authorEmails)
 	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string) db.GithubUserCache); ok {
-		r0 = returnFunc(ctx, authorEmail)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, []string) []db.GithubUserCache); ok {
+		r0 = returnFunc(ctx, authorEmails)
 	} else {
-		r0 = ret.Get(0).(db.GithubUserCache)
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]db.GithubUserCache)
+		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, string) error); ok {
-		r1 = returnFunc(ctx, authorEmail)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, []string) error); ok {
+		r1 = returnFunc(ctx, authorEmails)
 	} else {
 		r1 = ret.Error(1)
 	}
 	return r0, r1
 }
 
-// MockTx_GetGitHubUserCache_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetGitHubUserCache'
-type MockTx_GetGitHubUserCache_Call struct {
+// MockTx_GetGitHubUserCacheBatch_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetGitHubUserCacheBatch'
+type MockTx_GetGitHubUserCacheBatch_Call struct {
 	*mock.Call
 }
 
-// GetGitHubUserCache is a helper method to define mock.On call
+// GetGitHubUserCacheBatch is a helper method to define mock.On call
 //   - ctx context.Context
-//   - authorEmail string
-func (_e *MockTx_Expecter) GetGitHubUserCache(ctx interface{}, authorEmail interface{}) *MockTx_GetGitHubUserCache_Call {
-	return &MockTx_GetGitHubUserCache_Call{Call: _e.mock.On("GetGitHubUserCache", ctx, authorEmail)}
+//   - authorEmails []string
+func (_e *MockTx_Expecter) GetGitHubUserCacheBatch(ctx interface{}, authorEmails interface{}) *MockTx_GetGitHubUserCacheBatch_Call {
+	return &MockTx_GetGitHubUserCacheBatch_Call{Call: _e.mock.On("GetGitHubUserCacheBatch", ctx, authorEmails)}
 }
 
-func (_c *MockTx_GetGitHubUserCache_Call) Run(run func(ctx context.Context, authorEmail string)) *MockTx_GetGitHubUserCache_Call {
+func (_c *MockTx_GetGitHubUserCacheBatch_Call) Run(run func(ctx context.Context, authorEmails []string)) *MockTx_GetGitHubUserCacheBatch_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
 			arg0 = args[0].(context.Context)
 		}
-		var arg1 string
+		var arg1 []string
 		if args[1] != nil {
-			arg1 = args[1].(string)
+			arg1 = args[1].([]string)
 		}
 		run(
 			arg0,
@@ -3853,12 +3857,12 @@ func (_c *MockTx_GetGitHubUserCache_Call) Run(run func(ctx context.Context, auth
 	return _c
 }
 
-func (_c *MockTx_GetGitHubUserCache_Call) Return(githubUserCache db.GithubUserCache, err error) *MockTx_GetGitHubUserCache_Call {
-	_c.Call.Return(githubUserCache, err)
+func (_c *MockTx_GetGitHubUserCacheBatch_Call) Return(githubUserCaches []db.GithubUserCache, err error) *MockTx_GetGitHubUserCacheBatch_Call {
+	_c.Call.Return(githubUserCaches, err)
 	return _c
 }
 
-func (_c *MockTx_GetGitHubUserCache_Call) RunAndReturn(run func(ctx context.Context, authorEmail string) (db.GithubUserCache, error)) *MockTx_GetGitHubUserCache_Call {
+func (_c *MockTx_GetGitHubUserCacheBatch_Call) RunAndReturn(run func(ctx context.Context, authorEmails []string) ([]db.GithubUserCache, error)) *MockTx_GetGitHubUserCacheBatch_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -6024,53 +6028,55 @@ func (_c *MockRepository_GetDistinctTagValues_Call) RunAndReturn(run func(ctx co
 	return _c
 }
 
-// GetGitHubUserCache provides a mock function for the type MockRepository
-func (_mock *MockRepository) GetGitHubUserCache(ctx context.Context, authorEmail string) (db.GithubUserCache, error) {
-	ret := _mock.Called(ctx, authorEmail)
+// GetGitHubUserCacheBatch provides a mock function for the type MockRepository
+func (_mock *MockRepository) GetGitHubUserCacheBatch(ctx context.Context, authorEmails []string) ([]db.GithubUserCache, error) {
+	ret := _mock.Called(ctx, authorEmails)
 
 	if len(ret) == 0 {
-		panic("no return value specified for GetGitHubUserCache")
+		panic("no return value specified for GetGitHubUserCacheBatch")
 	}
 
-	var r0 db.GithubUserCache
+	var r0 []db.GithubUserCache
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string) (db.GithubUserCache, error)); ok {
-		return returnFunc(ctx, authorEmail)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, []string) ([]db.GithubUserCache, error)); ok {
+		return returnFunc(ctx, authorEmails)
 	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string) db.GithubUserCache); ok {
-		r0 = returnFunc(ctx, authorEmail)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, []string) []db.GithubUserCache); ok {
+		r0 = returnFunc(ctx, authorEmails)
 	} else {
-		r0 = ret.Get(0).(db.GithubUserCache)
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]db.GithubUserCache)
+		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, string) error); ok {
-		r1 = returnFunc(ctx, authorEmail)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, []string) error); ok {
+		r1 = returnFunc(ctx, authorEmails)
 	} else {
 		r1 = ret.Error(1)
 	}
 	return r0, r1
 }
 
-// MockRepository_GetGitHubUserCache_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetGitHubUserCache'
-type MockRepository_GetGitHubUserCache_Call struct {
+// MockRepository_GetGitHubUserCacheBatch_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetGitHubUserCacheBatch'
+type MockRepository_GetGitHubUserCacheBatch_Call struct {
 	*mock.Call
 }
 
-// GetGitHubUserCache is a helper method to define mock.On call
+// GetGitHubUserCacheBatch is a helper method to define mock.On call
 //   - ctx context.Context
-//   - authorEmail string
-func (_e *MockRepository_Expecter) GetGitHubUserCache(ctx interface{}, authorEmail interface{}) *MockRepository_GetGitHubUserCache_Call {
-	return &MockRepository_GetGitHubUserCache_Call{Call: _e.mock.On("GetGitHubUserCache", ctx, authorEmail)}
+//   - authorEmails []string
+func (_e *MockRepository_Expecter) GetGitHubUserCacheBatch(ctx interface{}, authorEmails interface{}) *MockRepository_GetGitHubUserCacheBatch_Call {
+	return &MockRepository_GetGitHubUserCacheBatch_Call{Call: _e.mock.On("GetGitHubUserCacheBatch", ctx, authorEmails)}
 }
 
-func (_c *MockRepository_GetGitHubUserCache_Call) Run(run func(ctx context.Context, authorEmail string)) *MockRepository_GetGitHubUserCache_Call {
+func (_c *MockRepository_GetGitHubUserCacheBatch_Call) Run(run func(ctx context.Context, authorEmails []string)) *MockRepository_GetGitHubUserCacheBatch_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
 			arg0 = args[0].(context.Context)
 		}
-		var arg1 string
+		var arg1 []string
 		if args[1] != nil {
-			arg1 = args[1].(string)
+			arg1 = args[1].([]string)
 		}
 		run(
 			arg0,
@@ -6080,12 +6086,12 @@ func (_c *MockRepository_GetGitHubUserCache_Call) Run(run func(ctx context.Conte
 	return _c
 }
 
-func (_c *MockRepository_GetGitHubUserCache_Call) Return(githubUserCache db.GithubUserCache, err error) *MockRepository_GetGitHubUserCache_Call {
-	_c.Call.Return(githubUserCache, err)
+func (_c *MockRepository_GetGitHubUserCacheBatch_Call) Return(githubUserCaches []db.GithubUserCache, err error) *MockRepository_GetGitHubUserCacheBatch_Call {
+	_c.Call.Return(githubUserCaches, err)
 	return _c
 }
 
-func (_c *MockRepository_GetGitHubUserCache_Call) RunAndReturn(run func(ctx context.Context, authorEmail string) (db.GithubUserCache, error)) *MockRepository_GetGitHubUserCache_Call {
+func (_c *MockRepository_GetGitHubUserCacheBatch_Call) RunAndReturn(run func(ctx context.Context, authorEmails []string) ([]db.GithubUserCache, error)) *MockRepository_GetGitHubUserCacheBatch_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/repository/repository.go
+++ b/internal/repository/repository.go
@@ -29,6 +29,7 @@ type Reads interface {
 	GetArtifactVersion(ctx context.Context, arg db.GetArtifactVersionParams) (db.ArtifactVersion, error)
 	GetArtifactVersionByID(ctx context.Context, id int64) (db.ArtifactVersion, error)
 	GetArtifactVersionSchema(ctx context.Context, arg db.GetArtifactVersionSchemaParams) ([]byte, error)
+	GetGitHubUserCache(ctx context.Context, authorEmail string) (db.GithubUserCache, error)
 	GetGroup(ctx context.Context, mavenID string) (db.Group, error)
 	GetPreviousVersion(ctx context.Context, arg db.GetPreviousVersionParams) (db.ArtifactVersion, error)
 	GroupExistsByMavenID(ctx context.Context, lower string) (bool, error)
@@ -49,6 +50,7 @@ type Reads interface {
 	ListVersionsNeedingEnrichment(ctx context.Context, arg db.ListVersionsNeedingEnrichmentParams) ([]db.ArtifactVersion, error)
 	ListEnrichedVersions(ctx context.Context, arg db.ListEnrichedVersionsParams) ([]db.ArtifactVersion, error)
 	ListVersionsNeedingChangelog(ctx context.Context, arg db.ListVersionsNeedingChangelogParams) ([]db.ArtifactVersion, error)
+	ListVersionsNeedingGitHubAuthorResolution(ctx context.Context, arg db.ListVersionsNeedingGitHubAuthorResolutionParams) ([]int64, error)
 	GetVersionDetail(ctx context.Context, groupID, artifactID, version string) (*VersionDetail, error)
 }
 
@@ -62,10 +64,12 @@ type Writes interface {
 	CreateGroup(ctx context.Context, arg db.CreateGroupParams) (db.Group, error)
 	DeleteArtifactVersionAssets(ctx context.Context, artifactVersionID int64) error
 	DeleteArtifactVersionTags(ctx context.Context, artifactVersionID int64) error
+	GetArtifactVersionForUpdate(ctx context.Context, id int64) (db.ArtifactVersion, error)
 	UpdateArtifactFields(ctx context.Context, arg db.UpdateArtifactFieldsParams) (db.Artifact, error)
 	UpdateArtifactVersionCommitBody(ctx context.Context, arg db.UpdateArtifactVersionCommitBodyParams) error
 	UpdateArtifactVersionOrder(ctx context.Context, arg db.UpdateArtifactVersionOrderParams) error
 	UpdateArtifactVersionSchema(ctx context.Context, arg db.UpdateArtifactVersionSchemaParams) error
+	UpsertGitHubUserCache(ctx context.Context, arg db.UpsertGitHubUserCacheParams) (db.GithubUserCache, error)
 }
 
 // Tx provides both read and write operations within a transaction.

--- a/internal/repository/repository.go
+++ b/internal/repository/repository.go
@@ -29,7 +29,7 @@ type Reads interface {
 	GetArtifactVersion(ctx context.Context, arg db.GetArtifactVersionParams) (db.ArtifactVersion, error)
 	GetArtifactVersionByID(ctx context.Context, id int64) (db.ArtifactVersion, error)
 	GetArtifactVersionSchema(ctx context.Context, arg db.GetArtifactVersionSchemaParams) ([]byte, error)
-	GetGitHubUserCache(ctx context.Context, authorEmail string) (db.GithubUserCache, error)
+	GetGitHubUserCacheBatch(ctx context.Context, authorEmails []string) ([]db.GithubUserCache, error)
 	GetGroup(ctx context.Context, mavenID string) (db.Group, error)
 	GetPreviousVersion(ctx context.Context, arg db.GetPreviousVersionParams) (db.ArtifactVersion, error)
 	GroupExistsByMavenID(ctx context.Context, lower string) (bool, error)

--- a/internal/workflow/changelog_batch.go
+++ b/internal/workflow/changelog_batch.go
@@ -367,7 +367,7 @@ func markPendingPredecessor( //nolint:gocritic // matches workflow signature
 
 func storeChangelogOnVersion(
 	ctx workflow.Context,
-	actCtx workflow.Context,
+	_ workflow.Context,
 	acts *activity.ChangelogActivities,
 	versionID int64,
 	changelog *domain.Changelog,
@@ -390,7 +390,13 @@ func storeChangelogOnVersion(
 	// We'll need a dedicated activity to update just the changelog field.
 	// For now, use a lightweight approach: store the changelog as part of a
 	// "changelog update" that reads the current commit_body and merges.
-	return workflow.ExecuteActivity(actCtx, acts.StoreChangelog, activity.StoreChangelogInput{
+	storeCtx := workflow.WithActivityOptions(ctx, workflow.ActivityOptions{
+		StartToCloseTimeout: 2 * time.Minute,
+		RetryPolicy: &temporal.RetryPolicy{
+			MaximumAttempts: 3,
+		},
+	})
+	return workflow.ExecuteActivity(storeCtx, acts.StoreChangelog, activity.StoreChangelogInput{
 		VersionID: versionID,
 		Changelog: *changelog,
 	}).Get(ctx, nil)

--- a/internal/workflow/changelog_batch.go
+++ b/internal/workflow/changelog_batch.go
@@ -367,7 +367,7 @@ func markPendingPredecessor( //nolint:gocritic // matches workflow signature
 
 func storeChangelogOnVersion(
 	ctx workflow.Context,
-	_ workflow.Context,
+	actCtx workflow.Context,
 	acts *activity.ChangelogActivities,
 	versionID int64,
 	changelog *domain.Changelog,
@@ -390,13 +390,7 @@ func storeChangelogOnVersion(
 	// We'll need a dedicated activity to update just the changelog field.
 	// For now, use a lightweight approach: store the changelog as part of a
 	// "changelog update" that reads the current commit_body and merges.
-	storeCtx := workflow.WithActivityOptions(ctx, workflow.ActivityOptions{
-		StartToCloseTimeout: 2 * time.Minute,
-		RetryPolicy: &temporal.RetryPolicy{
-			MaximumAttempts: 3,
-		},
-	})
-	return workflow.ExecuteActivity(storeCtx, acts.StoreChangelog, activity.StoreChangelogInput{
+	return workflow.ExecuteActivity(actCtx, acts.StoreChangelog, activity.StoreChangelogInput{
 		VersionID: versionID,
 		Changelog: *changelog,
 	}).Get(ctx, nil)

--- a/internal/workflow/github_author_resolution.go
+++ b/internal/workflow/github_author_resolution.go
@@ -34,40 +34,50 @@ func GitHubAuthorResolutionWorkflow(
 		},
 	})
 
-	var page activity.FetchGitHubAuthorResolutionPageOutput
+	var versionIDs []int64
 	err := workflow.ExecuteActivity(
 		fetchCtx,
-		activities.FetchGitHubAuthorResolutionPage,
-		activity.FetchGitHubAuthorResolutionPageInput{
+		activities.FetchVersionsNeedingAuthorResolution,
+		activity.FetchVersionsNeedingAuthorResolutionInput{
 			BeforeID: input.BeforeID,
 			PageSize: githubAuthorResolutionPageSize,
 		},
-	).Get(ctx, &page)
+	).Get(ctx, &versionIDs)
 	if err != nil {
 		return fmt.Errorf("fetching GitHub author resolution page: %w", err)
 	}
-	if len(page.VersionIDs) == 0 {
+	if len(versionIDs) == 0 {
 		return nil
 	}
 
 	resolveCtx := workflow.WithActivityOptions(ctx, workflow.ActivityOptions{
-		StartToCloseTimeout: 10 * time.Minute,
-		HeartbeatTimeout:    2 * time.Minute,
+		StartToCloseTimeout:    time.Minute,
+		ScheduleToCloseTimeout: 10 * time.Minute,
+		HeartbeatTimeout:       30 * time.Second,
 		RetryPolicy: &temporal.RetryPolicy{
-			MaximumAttempts: 3,
+			MaximumAttempts: 5,
 		},
 	})
 
+	var resolved activity.ResolveGitHubAuthorsBatchOutput
 	err = workflow.ExecuteActivity(
 		resolveCtx,
 		activities.ResolveGitHubAuthorsBatch,
-		activity.ResolveGitHubAuthorsBatchInput{VersionIDs: page.VersionIDs},
-	).Get(ctx, nil)
+		activity.ResolveGitHubAuthorsBatchInput{VersionIDs: versionIDs},
+	).Get(ctx, &resolved)
 	if err != nil {
 		return fmt.Errorf("resolving GitHub authors: %w", err)
 	}
+	workflow.GetLogger(ctx).Info("resolved GitHub author page",
+		"versionsStamped", resolved.VersionsStamped,
+		"authorsResolved", resolved.AuthorsResolved,
+		"authorsUnresolved", resolved.AuthorsUnresolved,
+	)
 
+	// Resolved rows leave the unresolved index, but skipped ones do not, so the
+	// cursor is what guarantees the scan keeps moving toward older versions.
+	nextBeforeID := versionIDs[len(versionIDs)-1]
 	return workflow.NewContinueAsNewError(ctx, GitHubAuthorResolutionWorkflow, GitHubAuthorResolutionInput{
-		BeforeID: page.NextBeforeID,
+		BeforeID: &nextBeforeID,
 	})
 }

--- a/internal/workflow/github_author_resolution.go
+++ b/internal/workflow/github_author_resolution.go
@@ -52,12 +52,9 @@ func GitHubAuthorResolutionWorkflow(
 
 	resolveCtx := workflow.WithActivityOptions(ctx, workflow.ActivityOptions{
 		StartToCloseTimeout: 10 * time.Minute,
-		HeartbeatTimeout:    30 * time.Second,
+		HeartbeatTimeout:    2 * time.Minute,
 		RetryPolicy: &temporal.RetryPolicy{
-			InitialInterval:    2 * time.Second,
-			BackoffCoefficient: 2,
-			MaximumInterval:    time.Minute,
-			MaximumAttempts:    3,
+			MaximumAttempts: 3,
 		},
 	})
 

--- a/internal/workflow/github_author_resolution.go
+++ b/internal/workflow/github_author_resolution.go
@@ -1,0 +1,76 @@
+package workflow
+
+import (
+	"fmt"
+	"time"
+
+	"go.temporal.io/sdk/temporal"
+	"go.temporal.io/sdk/workflow"
+
+	"github.com/spongepowered/systemofadownload/internal/activity"
+)
+
+const (
+	// GitHubAuthorResolutionScheduleID is the singleton schedule identifier.
+	GitHubAuthorResolutionScheduleID = "github-author-resolution"
+	githubAuthorResolutionPageSize   = 50
+)
+
+// GitHubAuthorResolutionInput carries the keyset cursor across continue-as-new runs.
+type GitHubAuthorResolutionInput struct {
+	BeforeID *int64
+}
+
+// GitHubAuthorResolutionWorkflow drains unresolved enriched versions newest-first.
+func GitHubAuthorResolutionWorkflow(
+	ctx workflow.Context,
+	input GitHubAuthorResolutionInput,
+) error {
+	var activities *activity.GitHubAuthorResolutionActivities
+	fetchCtx := workflow.WithActivityOptions(ctx, workflow.ActivityOptions{
+		StartToCloseTimeout: 30 * time.Second,
+		RetryPolicy: &temporal.RetryPolicy{
+			MaximumAttempts: 3,
+		},
+	})
+
+	var page activity.FetchGitHubAuthorResolutionPageOutput
+	err := workflow.ExecuteActivity(
+		fetchCtx,
+		activities.FetchGitHubAuthorResolutionPage,
+		activity.FetchGitHubAuthorResolutionPageInput{
+			BeforeID: input.BeforeID,
+			PageSize: githubAuthorResolutionPageSize,
+		},
+	).Get(ctx, &page)
+	if err != nil {
+		return fmt.Errorf("fetching GitHub author resolution page: %w", err)
+	}
+	if len(page.VersionIDs) == 0 {
+		return nil
+	}
+
+	resolveCtx := workflow.WithActivityOptions(ctx, workflow.ActivityOptions{
+		StartToCloseTimeout: 10 * time.Minute,
+		HeartbeatTimeout:    30 * time.Second,
+		RetryPolicy: &temporal.RetryPolicy{
+			InitialInterval:    2 * time.Second,
+			BackoffCoefficient: 2,
+			MaximumInterval:    time.Minute,
+			MaximumAttempts:    3,
+		},
+	})
+
+	err = workflow.ExecuteActivity(
+		resolveCtx,
+		activities.ResolveGitHubAuthorsBatch,
+		activity.ResolveGitHubAuthorsBatchInput{VersionIDs: page.VersionIDs},
+	).Get(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("resolving GitHub authors: %w", err)
+	}
+
+	return workflow.NewContinueAsNewError(ctx, GitHubAuthorResolutionWorkflow, GitHubAuthorResolutionInput{
+		BeforeID: page.NextBeforeID,
+	})
+}

--- a/internal/workflow/github_author_resolution_test.go
+++ b/internal/workflow/github_author_resolution_test.go
@@ -1,0 +1,78 @@
+package workflow_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/mock"
+	"go.temporal.io/sdk/testsuite"
+	sdkworkflow "go.temporal.io/sdk/workflow"
+
+	"github.com/spongepowered/systemofadownload/internal/activity"
+	"github.com/spongepowered/systemofadownload/internal/workflow"
+)
+
+func TestGitHubAuthorResolutionWorkflow(t *testing.T) {
+	t.Parallel()
+
+	var activities *activity.GitHubAuthorResolutionActivities
+	tests := []struct {
+		name         string
+		page         activity.FetchGitHubAuthorResolutionPageOutput
+		setup        func(*testsuite.TestWorkflowEnvironment)
+		wantContinue bool
+	}{
+		{
+			name: "completes on empty page",
+			page: activity.FetchGitHubAuthorResolutionPageOutput{},
+		},
+		{
+			name: "resolves page and continues as new",
+			page: activity.FetchGitHubAuthorResolutionPageOutput{
+				VersionIDs: []int64{10, 9},
+				NextBeforeID: func() *int64 {
+					value := int64(9)
+					return &value
+				}(),
+			},
+			setup: func(env *testsuite.TestWorkflowEnvironment) {
+				env.OnActivity(
+					activities.ResolveGitHubAuthorsBatch,
+					mock.Anything,
+					activity.ResolveGitHubAuthorsBatchInput{VersionIDs: []int64{10, 9}},
+				).Return(nil)
+			},
+			wantContinue: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			var suite testsuite.WorkflowTestSuite
+			env := suite.NewTestWorkflowEnvironment()
+			env.OnActivity(
+				activities.FetchGitHubAuthorResolutionPage,
+				mock.Anything,
+				activity.FetchGitHubAuthorResolutionPageInput{PageSize: 50},
+			).Return(&tt.page, nil)
+			if tt.setup != nil {
+				tt.setup(env)
+			}
+
+			env.ExecuteWorkflow(
+				workflow.GitHubAuthorResolutionWorkflow,
+				workflow.GitHubAuthorResolutionInput{},
+			)
+			err := env.GetWorkflowError()
+			if !tt.wantContinue {
+				if err != nil {
+					t.Fatalf("workflow error = %v", err)
+				}
+				return
+			}
+			if !sdkworkflow.IsContinueAsNewError(err) {
+				t.Fatalf("workflow error = %T %v, want continue-as-new", err, err)
+			}
+		})
+	}
+}

--- a/internal/workflow/github_author_resolution_test.go
+++ b/internal/workflow/github_author_resolution_test.go
@@ -17,29 +17,22 @@ func TestGitHubAuthorResolutionWorkflow(t *testing.T) {
 	var activities *activity.GitHubAuthorResolutionActivities
 	tests := []struct {
 		name         string
-		page         activity.FetchGitHubAuthorResolutionPageOutput
+		versionIDs   []int64
 		setup        func(*testsuite.TestWorkflowEnvironment)
 		wantContinue bool
 	}{
 		{
 			name: "completes on empty page",
-			page: activity.FetchGitHubAuthorResolutionPageOutput{},
 		},
 		{
-			name: "resolves page and continues as new",
-			page: activity.FetchGitHubAuthorResolutionPageOutput{
-				VersionIDs: []int64{10, 9},
-				NextBeforeID: func() *int64 {
-					value := int64(9)
-					return &value
-				}(),
-			},
+			name:       "resolves page and continues as new",
+			versionIDs: []int64{10, 9},
 			setup: func(env *testsuite.TestWorkflowEnvironment) {
 				env.OnActivity(
 					activities.ResolveGitHubAuthorsBatch,
 					mock.Anything,
 					activity.ResolveGitHubAuthorsBatchInput{VersionIDs: []int64{10, 9}},
-				).Return(nil)
+				).Return(&activity.ResolveGitHubAuthorsBatchOutput{VersionsStamped: 2}, nil)
 			},
 			wantContinue: true,
 		},
@@ -51,10 +44,10 @@ func TestGitHubAuthorResolutionWorkflow(t *testing.T) {
 			var suite testsuite.WorkflowTestSuite
 			env := suite.NewTestWorkflowEnvironment()
 			env.OnActivity(
-				activities.FetchGitHubAuthorResolutionPage,
+				activities.FetchVersionsNeedingAuthorResolution,
 				mock.Anything,
-				activity.FetchGitHubAuthorResolutionPageInput{PageSize: 50},
-			).Return(&tt.page, nil)
+				activity.FetchVersionsNeedingAuthorResolutionInput{PageSize: 50},
+			).Return(tt.versionIDs, nil)
 			if tt.setup != nil {
 				tt.setup(env)
 			}

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -482,6 +482,8 @@ components:
               type: string
             email:
               type: string
+            githubUsername:
+              type: string
         link:
           type: string
           format: URL


### PR DESCRIPTION
## Description

This PR adds GitHub profile links for contributors to each version, allowing better attribution, as well as consistency for people who accidentally commit under multiple emails. It's done transparently, so any commits that do not have this data will fallback to the old system, making this non-breaking.

The only caveat here is that it _does_ add requests to the GitHub API. For rate limit purposes, I've allow an _optional_ GitHub token to be supplied to benefit from higher limits, however it'll work fine by default with the lower limits. If it fails, it'll just not store the data. Main goal with this is to keep it non-breaking, and never let these additional requests hold back a build, eg during a GitHub outage.

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [X] `feat`: New feature (non-breaking change which adds functionality)
- [ ] `fix`: Bug fix (non-breaking change which fixes an issue)
- [ ] `docs`: Documentation update
- [ ] `refactor`: Code refactoring (no functional changes)
- [ ] `perf`: Performance improvement
- [ ] `test`: Adding or updating tests
- [ ] `chore`: Maintenance tasks (dependencies, tooling, etc.)
- [ ] `ci`: CI/CD configuration changes
- [ ] **BREAKING CHANGE**: This change breaks backwards compatibility

## Testing

<!-- Describe the tests you ran and how to reproduce them -->

- [X] Tests pass locally with `go test ./...`
- [X] Added/updated tests for new functionality
- [X] Generated code is up to date (`go generate ./...`)

## Commit Message Format

<!-- 
Ensure your PR title follows conventional commits format:
- feat: add new feature
- fix: correct bug
- docs: update documentation

See RELEASES.md for more details.
-->

## Checklist

- [X] My code follows the project's style guidelines
- [X] I have run `go generate ./...` to update generated code
- [X] I have updated documentation as needed
- [X] My changes do not introduce new warnings or errors
- [X] I have added tests that prove my fix/feature works
- [X] All tests pass locally
